### PR TITLE
Fix for percent variation in file generation

### DIFF
--- a/app/presenters/cfd_transaction_file_presenter.rb
+++ b/app/presenters/cfd_transaction_file_presenter.rb
@@ -63,7 +63,7 @@ class CfdTransactionFilePresenter < SimpleDelegator
       td.line_attr_4,
       td.category_description, # was line_attr_5
       td.baseline_charge,     # line_attr_6
-      td.line_attr_9,         # line_attr_7 (compliance band)
+      td.variation_percentage,     # line_attr_7 (compliance band)
       td.temporary_cessation_file, # temporary cessation
       "",                     # line_attr_9   future - compliance band
       "",                     # line_attr_10  future - compliance adjustment

--- a/app/services/annual_billing_data_file_service.rb
+++ b/app/services/annual_billing_data_file_service.rb
@@ -126,6 +126,8 @@ class AnnualBillingDataFileService
                   i = Integer(val.to_s, 10)
                   if i < 0 || i > 100
                     raise ArgumentError
+                  else
+                    val += '%' unless val.include?('%')
                   end
                 rescue ArgumentError => e
                   failed = true

--- a/test/fixtures/transaction_details.yml
+++ b/test/fixtures/transaction_details.yml
@@ -58,6 +58,7 @@ cfd:
   period_end: "10-Aug-2017"
   original_filename: 'CFDAI00371'
   original_file_date: <%= 2.months.ago.to_date %>
+  tcm_financial_year: "1718"
 
 cfd_b:
   transaction_header: cfd_b
@@ -119,6 +120,7 @@ cfd_b:
   period_end: "10-Aug-2017"
   original_filename: 'CFDBI00374'
   original_file_date: <%= 2.weeks.ago.to_date %>
+  tcm_financial_year: "1718"
 
 cfd_historic:
   transaction_header: cfd
@@ -180,6 +182,7 @@ cfd_historic:
   period_end: "10-Aug-2017"
   original_filename: 'CFDAI00371'
   original_file_date: <%= 2.months.ago.to_date %>
+  tcm_financial_year: "1718"
 
 pas:
   transaction_header: pas
@@ -241,6 +244,7 @@ pas:
   period_end: "31 Mar 2018"
   original_filename: 'PASYI00337'
   original_file_date: <%= 6.weeks.ago.to_date %>
+  tcm_financial_year: "1718"
 
 pas_historic:
   transaction_header: pas
@@ -302,3 +306,4 @@ pas_historic:
   period_end: "31 Mar 2018"
   original_filename: 'PASYI00337'
   original_file_date: <%= 6.weeks.ago.to_date %>
+  tcm_financial_year: "1718"

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -7,17 +7,20 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
   end
 
   def test_it_returns_charge_params
-    assert_equal(@presenter.charge_params, {
-      permitCategoryRef: @transaction.category,
-      percentageAdjustment: clean_variation,
-      temporaryCessation: @presenter.temporary_cessation,
-      compliancePerformanceBand: 'B',
-      billableDays: billable_days,
-      financialDays: financial_year_days,
-      chargePeriod: charge_period,
-      preConstruction: false,
-      environmentFlag: 'TEST'
-    })
+    assert_equal(
+      {
+        permitCategoryRef: @transaction.category,
+        percentageAdjustment: clean_variation,
+        temporaryCessation: @presenter.temporary_cessation,
+        compliancePerformanceBand: 'B',
+        billableDays: billable_days,
+        financialDays: financial_year_days,
+        chargePeriod: charge_period,
+        preConstruction: false,
+        environmentFlag: 'TEST'
+      },
+      @presenter.charge_params
+    )
   end
 
   def test_it_returns_discharge_description
@@ -72,6 +75,8 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal(@presenter.as_json, {
       id: @transaction.id,
       customer_reference: @presenter.customer_reference,
+      tcm_transaction_reference: @presenter.tcm_transaction_reference,
+      generated_filename: @presenter.generated_filename,
       original_filename: @presenter.original_filename,
       original_file_date: @presenter.original_file_date,
       consent_reference: @presenter.consent_reference,
@@ -80,14 +85,17 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
       sroc_category: @presenter.category,
       variation: @presenter.clean_variation_percentage,
       temporary_cessation: @presenter.temporary_cessation_flag,
+      financial_year: @presenter.charge_period,
+      region: @presenter.region_from_ref,
       period: @presenter.period,
       amount: @presenter.amount
     })
   end
 
   def clean_variation
-    return 100 if @transaction.line_attr_9.blank?
-    @transaction.line_attr_9.gsub(/%/, '')
+    v = @transaction.variation || @transaction.line_attr_9
+    return 100 if v.blank?
+    v.gsub(/%/, '')
   end
 
   def financial_year_days
@@ -106,7 +114,6 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
   end
 
   def charge_period
-    year = financial_year - 2000
-    "FY#{year}#{year + 1}"
+    "FY#{@transaction.tcm_financial_year}"
   end
 end

--- a/test/services/annual_billing_data_file_service_test.rb
+++ b/test/services/annual_billing_data_file_service_test.rb
@@ -106,6 +106,18 @@ class AnnualBillingDataFileServiceTest < ActiveSupport::TestCase
     assert_equal(false, transaction.temporary_cessation)
   end
 
+  def test_import_stores_variation_with_an_percent_suffix
+    file = file_fixture('cfd_abd.csv')
+    upload = prepare_upload(file)
+
+    @service.import(upload, file)
+    transaction = transaction_details(:cfd)
+    assert transaction.variation.end_with?('%')
+
+    transaction = transaction_details(:cfd_b)
+    assert transaction.variation.end_with?('%')
+  end
+
   def test_import_records_total_and_errors
     file = file_fixture('cfd_abd.csv')
     upload = prepare_upload(file)


### PR DESCRIPTION
Generated files didn't include updated variation percentage when changed by annual billing import.