### PR TITLE
Fixed issue with trailer totals

### DIFF
--- a/app/presenters/cfd_transaction_file_presenter.rb
+++ b/app/presenters/cfd_transaction_file_presenter.rb
@@ -84,14 +84,22 @@ class CfdTransactionFilePresenter < SimpleDelegator
       "T",
       padded_number(count + 1),
       padded_number(count + 2),
-      invoice_total,
-      credit_total
+      trailer_invoice_total,
+      trailer_credit_total
     ]
   end
 
 protected
   def transaction_file
     __getobj__
+  end
+
+  def trailer_invoice_total
+    transaction_details.where(tcm_transaction_type: 'I').sum(:tcm_charge).to_i
+  end
+
+  def trailer_credit_total
+    transaction_details.where(tcm_transaction_type: 'C').sum(:tcm_charge).to_i
   end
 
   def record_count

--- a/test/fixtures/transaction_details.yml
+++ b/test/fixtures/transaction_details.yml
@@ -1,126 +1,138 @@
-cfd:
-  transaction_header: cfd
+defaults: &defaults
   sequence_number: 1
+  related_reference: ""
+  currency_code: "GBP"
+  header_narrative: ""
+  header_attr_1: "20-AUG-2017"
+  header_attr_2: ""
+  header_attr_3: ""
+  header_attr_4: ""
+  header_attr_5: ""
+  header_attr_6: ""
+  header_attr_7: ""
+  header_attr_8: ""
+  header_attr_9: ""
+  header_attr_10: ""
+  line_vat_code: ""
+  line_area_code: "3"
+  line_income_stream_code: "C"
+  line_context_code: "D"
+  line_attr_1: "Blue Rd. Haystack Disposal"
+  line_attr_2: "STORM SEWAGE OVERFLOW"
+  line_attr_3: "01/04/17 - 10/08/17"
+  line_attr_4: "365/132"
+  line_attr_5: "C 1"
+  line_attr_6: "E 1"
+  line_attr_7: "S 1"
+  line_attr_8: "684"
+  line_attr_9: "96%"
+  line_attr_10: ""
+  line_attr_11: ""
+  line_attr_12: ""
+  line_attr_13: ""
+  line_attr_14: ""
+  line_attr_15: ""
+  line_quantity: 1
+  unit_of_measure: "Each"
+  generated_filename:
+  generated_file_at:
+  temporary_cessation: false
+  temporary_cessation_start:
+  temporary_cessation_end:
+  category:
+  charge_calculation:
+  period_start: "01-Apr-2017"
+  period_end: "10-Aug-2017"
+  original_filename: 'CFDBI00123'
+  original_file_date: <%= 2.weeks.ago.to_date %>
+  tcm_financial_year: "1718"
+
+cfd:
+  <<: *defaults
+  transaction_header: cfd
   customer_reference: "A60425822C"
   transaction_date: <%= 2.months.ago %>
   transaction_type: "C"
   transaction_reference: "826951A"
-  related_reference: ""
-  currency_code: "GBP"
-  header_narrative: ""
-  header_attr_1: "29-AUG-2017"
-  header_attr_2: ""
-  header_attr_3: ""
-  header_attr_4: ""
-  header_attr_5: ""
-  header_attr_6: ""
-  header_attr_7: ""
-  header_attr_8: ""
-  header_attr_9: ""
-  header_attr_10: ""
   line_amount: 23747
-  line_vat_code: ""
-  line_area_code: "3"
   line_description: "Consent No - ANQA/1234/1/1"
-  line_income_stream_code: "C"
-  line_context_code: "D"
   line_attr_1: "Green Rd. Pig Disposal"
-  line_attr_2: "STORM SEWAGE OVERFLOW"
-  line_attr_3: "01/04/17 - 10/08/17"
-  line_attr_4: "365/132"
-  line_attr_5: "C 1"
-  line_attr_6: "E 1"
-  line_attr_7: "S 1"
-  line_attr_8: "684"
-  line_attr_9: "96%"
-  line_attr_10: ""
-  line_attr_11: ""
-  line_attr_12: ""
-  line_attr_13: ""
-  line_attr_14: ""
-  line_attr_15: ""
-  line_quantity: 1
-  unit_of_measure: "Each"
   unit_of_measure_price: 23747
   status: "unbilled"
-  filename:
   reference_1: "ANQA/1234/1/1"
   reference_2: "1"
   reference_3: "1"
-  generated_filename:
-  generated_file_at:
   temporary_cessation: false
-  temporary_cessation_start:
-  temporary_cessation_end:
-  category:
-  charge_calculation:
-  period_start: "01-Apr-2017"
-  period_end: "10-Aug-2017"
-  original_filename: 'CFDAI00371'
-  original_file_date: <%= 2.months.ago.to_date %>
-  tcm_financial_year: "1718"
 
 cfd_b:
+  <<: *defaults
   transaction_header: cfd_b
-  sequence_number: 1
   customer_reference: "A232211C"
   transaction_date: <%= 2.months.ago %>
   transaction_type: "C"
-  transaction_reference: "123499A"
-  related_reference: ""
-  currency_code: "GBP"
-  header_narrative: ""
-  header_attr_1: "19-NOV-2017"
-  header_attr_2: ""
-  header_attr_3: ""
-  header_attr_4: ""
-  header_attr_5: ""
-  header_attr_6: ""
-  header_attr_7: ""
-  header_attr_8: ""
-  header_attr_9: ""
-  header_attr_10: ""
+  transaction_reference: "826951A"
   line_amount: 23747
-  line_vat_code: ""
-  line_area_code: "3"
   line_description: "Consent No - ANNF/1754/1/1"
-  line_income_stream_code: "C"
-  line_context_code: "D"
   line_attr_1: "Green Rd. Pig Disposal"
-  line_attr_2: "STORM SEWAGE OVERFLOW"
-  line_attr_3: "01/04/17 - 10/08/17"
-  line_attr_4: "365/132"
-  line_attr_5: "C 1"
-  line_attr_6: "E 1"
-  line_attr_7: "S 1"
-  line_attr_8: "684"
-  line_attr_9: "96%"
-  line_attr_10: ""
-  line_attr_11: ""
-  line_attr_12: ""
-  line_attr_13: ""
-  line_attr_14: ""
-  line_attr_15: ""
-  line_quantity: 1
-  unit_of_measure: "Each"
   unit_of_measure_price: 23747
   status: "unbilled"
-  filename:
   reference_1: "ANNF/1754/1/1"
   reference_2: "1"
   reference_3: "1"
-  generated_filename:
-  generated_file_at:
   temporary_cessation: false
-  temporary_cessation_start:
-  temporary_cessation_end:
-  category:
-  charge_calculation:
+  original_filename: 'CFDBI00374'
+
+cfd_charged_1:
+  <<: *defaults
+  transaction_header: cfd_b
+  customer_reference: "A220368M"
+  transaction_date: <%= 2.months.ago %>
+  transaction_type: "C"
+  transaction_reference: "123429A"
+  header_attr_1: "20-AUG-2017"
+  line_amount: -12345
+  line_description: "Consent No - TONY/1234/1/1"
+  line_attr_1: "Blue Rd. Haystack Disposal"
+  unit_of_measure_price: -12345
+  status: "unbilled"
+  reference_1: "TONY/1234/1/1"
+  reference_2: "1"
+  reference_3: "1"
+  temporary_cessation: false
+  category: "2.3.4"
   period_start: "01-Apr-2017"
   period_end: "10-Aug-2017"
-  original_filename: 'CFDBI00374'
+  original_filename: 'CFDBI00123'
   original_file_date: <%= 2.weeks.ago.to_date %>
   tcm_financial_year: "1718"
+  tcm_charge: -96803
+  tcm_transaction_type: 'I'
+
+cfd_charged_2:
+  <<: *defaults
+  transaction_header: cfd_b
+  customer_reference: "A220368M"
+  transaction_date: <%= 2.months.ago %>
+  transaction_type: "I"
+  transaction_reference: "123429A"
+  header_attr_1: "20-AUG-2017"
+  line_amount: 23747
+  line_description: "Consent No - TONY/1234/1/1"
+  line_attr_1: "Blue Rd. Haystack Disposal"
+  unit_of_measure_price: 23747
+  status: "unbilled"
+  reference_1: "TONY/1234/1/1"
+  reference_2: "1"
+  reference_3: "1"
+  temporary_cessation: false
+  category: "2.3.4"
+  period_start: "01-Apr-2017"
+  period_end: "10-Aug-2017"
+  original_filename: 'CFDBI00123'
+  original_file_date: <%= 2.weeks.ago.to_date %>
+  tcm_financial_year: "1718"
+  tcm_charge: 196803
+  tcm_transaction_type: 'I'
 
 cfd_historic:
   transaction_header: cfd
@@ -176,7 +188,7 @@ cfd_historic:
   temporary_cessation: false
   temporary_cessation_start:
   temporary_cessation_end:
-  category:
+  category: "2.3.1"
   charge_calculation:
   period_start: "01-Apr-2017"
   period_end: "10-Aug-2017"

--- a/test/fixtures/transaction_files.yml
+++ b/test/fixtures/transaction_files.yml
@@ -5,9 +5,11 @@ cfd_retro_file:
   region: 'A'
   retrospective: true
   file_id: "00123"
+  generated_at: <%= 1.month.ago %>
 
 cfd_sroc_file:
   regime: cfd
   region: 'B'
   retrospective: false
   file_id: "05678T"
+  generated_at: <%= 1.hour.ago %>

--- a/test/presenters/cfd_transaction_file_presenter_test.rb
+++ b/test/presenters/cfd_transaction_file_presenter_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper.rb'
+
+class CfdTransactionFilePresenterTest < ActiveSupport::TestCase
+  def setup
+    @transaction_1 = transaction_details(:cfd_charged_1)
+    @transaction_2 = transaction_details(:cfd_charged_2)
+    set_charge_calculation(@transaction_1)
+    set_charge_calculation(@transaction_2)
+
+    @file = transaction_files(:cfd_sroc_file)
+    @file.transaction_details << @transaction_1
+    @file.transaction_details << @transaction_2
+
+    @presenter = CfdTransactionFilePresenter.new(@file)
+  end
+
+  def test_it_returns_a_header_record
+    assert_equal(
+      [
+        "H",
+        "0000000",
+        "CFD",
+        "B",
+        "I",
+        @file.file_id,
+        "",
+        @file.generated_at.strftime("%-d-%^b-%Y")
+      ],
+      @presenter.header
+    )
+  end
+
+  def test_it_produces_detail_records
+    rows = []
+    @presenter.details do |row|
+      rows << row
+    end
+    assert_equal(2, rows.count)
+  end
+
+  def test_is_returns_a_trailer_record
+    count = @presenter.transaction_details.count
+    assert_equal(
+      [
+        "T",
+        (count + 1).to_s.rjust(7, '0'),
+        (count + 2).to_s.rjust(7, '0'),
+        @presenter.transaction_details.where(tcm_transaction_type: 'I').sum(:tcm_charge).to_i,
+        @presenter.transaction_details.where(tcm_transaction_type: 'C').sum(:tcm_charge).to_i
+      ],
+      @presenter.trailer
+    )
+  end
+
+  def set_charge_calculation(transaction)
+    transaction.charge_calculation = {
+      'calculation' => {
+        'chargeAmount' => transaction.tcm_charge.abs,
+        'decisionPoints' => {
+          'baselineCharge' => 196803
+        }
+      },
+      'generatedAt' => '10-AUG-2017'
+    }
+    transaction.save
+  end
+end


### PR DESCRIPTION
Fixed issue where credit and invoice totals should be summed from the grouped 'C' and 'I' transactions not individual credit or debit transaction lines.