### PR TITLE
Fixed issue with pro rata days in reverse order

### DIFF
--- a/app/presenters/cfd_transaction_detail_presenter.rb
+++ b/app/presenters/cfd_transaction_detail_presenter.rb
@@ -17,6 +17,10 @@ class CfdTransactionDetailPresenter < TransactionDetailPresenter
     transaction_detail.original_file_date.strftime("%d/%m/%y")
   end
 
+  def pro_rata_days
+    "#{billable_days}/#{financial_year_days}"
+  end
+
   def transaction_date
     transaction_detail.transaction_date.strftime("%d/%m/%y")
   end

--- a/app/presenters/cfd_transaction_file_presenter.rb
+++ b/app/presenters/cfd_transaction_file_presenter.rb
@@ -60,7 +60,7 @@ class CfdTransactionFilePresenter < SimpleDelegator
       td.line_description,    # line_attr_1
       td.line_attr_3,         # line_attr_2
       td.category,            # line_attr_3
-      td.line_attr_4,
+      td.pro_rata_days,       # line_attr_4
       td.category_description, # was line_attr_5
       td.baseline_charge,     # line_attr_6
       td.variation_percentage,     # line_attr_7 (compliance band)

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -31,12 +31,27 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal(@presenter.site, @transaction.line_attr_1)
   end
 
+  def test_pro_rata_days_is_correctly_formatted
+    days = @presenter.line_attr_4.split('/')
+    assert_equal("#{days[1]}/#{days[0]}", @presenter.pro_rata_days)
+  end
+
   def test_it_returns_billable_days
     assert_equal(@presenter.billable_days, billable_days)
   end
 
+  def test_billable_days_match_line_attr_4_part
+    days = @presenter.line_attr_4.split('/')
+    assert_equal(days[1].to_i, @presenter.billable_days)
+  end
+
   def test_it_returns_financial_year_days
     assert_equal(@presenter.financial_year_days, financial_year_days)
+  end
+
+  def test_financial_year_days_match_line_attr_4_part
+    days = @presenter.line_attr_4.split('/')
+    assert_equal(days[0].to_i, @presenter.financial_year_days)
   end
 
   def test_it_returns_financial_year

--- a/test/presenters/cfd_transaction_file_presenter_test.rb
+++ b/test/presenters/cfd_transaction_file_presenter_test.rb
@@ -38,6 +38,14 @@ class CfdTransactionFilePresenterTest < ActiveSupport::TestCase
     assert_equal(2, rows.count)
   end
 
+  def test_detail_records_have_correct_line_attr_4_pro_rata_days
+    @presenter.transaction_details.each_with_index do |td, i|
+      p = CfdTransactionDetailPresenter.new(td)
+      row = @presenter.detail_row(p, i)
+      assert_equal(p.pro_rata_days, row[28])
+    end
+  end
+
   def test_is_returns_a_trailer_record
     count = @presenter.transaction_details.count
     assert_equal(


### PR DESCRIPTION
Incoming line attribute 4 is in `financial_year_day/billable_days` order e.g. `365/234`, for the new output format we want this order reversed i.e. `billable_days/financial_year_days` - e.g. `234/365`