### PR TITLE
Fixed temporary cessation output value in files

### DIFF
--- a/app/presenters/transaction_detail_presenter.rb
+++ b/app/presenters/transaction_detail_presenter.rb
@@ -68,7 +68,7 @@ class TransactionDetailPresenter < SimpleDelegator
   end
 
   def temporary_cessation_file
-    temporary_cessation? ? 'Y' : ''
+    temporary_cessation? ? '50%' : ''
   end
 
   def temporary_cessation_flag

--- a/test/controllers/transaction_files_controller_test.rb
+++ b/test/controllers/transaction_files_controller_test.rb
@@ -12,11 +12,10 @@ class TransactionFilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  def test_create_should_redirect_to_transactions_to_be_billed
-    skip("needs reworking")
+  # def test_create_should_redirect_to_transactions_to_be_billed
     # @regimes.each do |regime|
     #   post regime_transaction_files_url(regime), params: { region: 'A' }
     #   assert_redirected_to regime_transactions_path(regime)
     # end
-  end
+  # end
 end

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -86,6 +86,13 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal(@presenter.discharge_reference, @transaction.reference_3)
   end
 
+  def test_temporary_cessation_file_returns_50_percent_or_blank
+    @presenter.temporary_cessation = true
+    assert_equal('50%', @presenter.temporary_cessation_file)
+    @presenter.temporary_cessation = false
+    assert_equal('', @presenter.temporary_cessation_file)
+  end
+
   def test_it_transforms_into_json
     assert_equal(@presenter.as_json, {
       id: @transaction.id,

--- a/test/presenters/cfd_transaction_file_presenter_test.rb
+++ b/test/presenters/cfd_transaction_file_presenter_test.rb
@@ -46,6 +46,17 @@ class CfdTransactionFilePresenterTest < ActiveSupport::TestCase
     end
   end
 
+  def test_detail_records_have_correct_temporary_cessation_value
+    @presenter.transaction_details.each_with_index do |td, i|
+      td.temporary_cessation = i.odd?
+      expected_value = i.odd? ? '50%' : ''
+
+      p = CfdTransactionDetailPresenter.new(td)
+      row = @presenter.detail_row(p, i)
+      assert_equal expected_value, row[32]
+    end
+  end
+
   def test_is_returns_a_trailer_record
     count = @presenter.transaction_details.count
     assert_equal(


### PR DESCRIPTION
Temporary cessation flag should be output as `'50%'`when `true` and `''` (empty string) when `false` in annual billing files.