### PR TITLE
Fixed file transaction date to match file creation date

### DIFF
--- a/app/presenters/cfd_transaction_detail_presenter.rb
+++ b/app/presenters/cfd_transaction_detail_presenter.rb
@@ -25,10 +25,6 @@ class CfdTransactionDetailPresenter < TransactionDetailPresenter
     transaction_detail.transaction_date.strftime("%d/%m/%y")
   end
 
-  def file_transaction_date
-    transaction_detail.transaction_date.strftime("%-d-%^b-%Y")
-  end
-
   def clean_variation_percentage
     return 100 if variation_percentage.blank?
     variation_percentage.gsub(/%/,'')

--- a/app/presenters/cfd_transaction_file_presenter.rb
+++ b/app/presenters/cfd_transaction_file_presenter.rb
@@ -35,13 +35,13 @@ class CfdTransactionFilePresenter < SimpleDelegator
       "D",
       padded_number(idx),
       td.customer_reference,
-      td.file_transaction_date,
+      file_generated_at,
       td.tcm_transaction_type,
       td.tcm_transaction_reference,
       "",
       "GBP",
       "",                     # header_narrative always blank
-      td.file_transaction_date,  # header_attr_1
+      file_generated_at,      # header_attr_1
       "",                     # header_attr_2
       "",                     # header_attr_3
       "",                     # header_attr_4
@@ -100,6 +100,10 @@ protected
 
   def trailer_credit_total
     transaction_details.where(tcm_transaction_type: 'C').sum(:tcm_charge).to_i
+  end
+  
+  def file_generated_at
+    generated_at.strftime("%d-%^b-%Y")
   end
 
   def record_count

--- a/test/presenters/cfd_transaction_file_presenter_test.rb
+++ b/test/presenters/cfd_transaction_file_presenter_test.rb
@@ -57,6 +57,16 @@ class CfdTransactionFilePresenterTest < ActiveSupport::TestCase
     end
   end
 
+  def test_detail_record_has_correct_transaction_date
+    expected_value = @file.generated_at.strftime("%d-%^b-%Y") # DD-MMM-YYYY format
+    @presenter.transaction_details.each_with_index do |td, i|
+      p = CfdTransactionDetailPresenter.new(td)
+      row = @presenter.detail_row(p, i)
+      assert_equal expected_value, row[3]
+      assert_equal expected_value, row[9]
+    end
+  end
+
   def test_is_returns_a_trailer_record
     count = @presenter.transaction_details.count
     assert_equal(


### PR DESCRIPTION
The 2 transaction date fields in a transaction file detail line should be set to the date the file was generated in the TCM instead of the date the file was generated in the source system.