### PR TITLE
Removed prefix from consent number in output file

### DIFF
--- a/app/presenters/cfd_transaction_file_presenter.rb
+++ b/app/presenters/cfd_transaction_file_presenter.rb
@@ -57,7 +57,7 @@ class CfdTransactionFilePresenter < SimpleDelegator
       td.discharge_location,  # line_description
       "CT",                   # line income stream code
       td.line_context_code,
-      td.line_description,    # line_attr_1
+      td.consent_reference,   # line_attr_1
       td.line_attr_3,         # line_attr_2
       td.category,            # line_attr_3
       td.pro_rata_days,       # line_attr_4

--- a/test/presenters/cfd_transaction_file_presenter_test.rb
+++ b/test/presenters/cfd_transaction_file_presenter_test.rb
@@ -67,6 +67,17 @@ class CfdTransactionFilePresenterTest < ActiveSupport::TestCase
     end
   end
 
+  def test_detail_record_consent_number_not_prefixed
+    # consent no. shouldn't be prefixed with 'Consent No - ' or 
+    # 'Authorization No ' as per the incoming file value
+    @presenter.transaction_details.each_with_index do |td, i|
+      expected_value = td.reference_1
+      p = CfdTransactionDetailPresenter.new(td)
+      row = @presenter.detail_row(p, i)
+      assert_equal expected_value, row[25]
+    end
+  end
+
   def test_is_returns_a_trailer_record
     count = @presenter.transaction_details.count
     assert_equal(


### PR DESCRIPTION
Incoming transaction files have the consent number prefixed with `Consent No - ` or `Authorization No `. In the TCM generated files we do not want those prefixes.