### PR TITLE
Added ability to control retrospective cutoff date via SystemConfig

### DIFF
--- a/app/lib/tcm_utils.rb
+++ b/app/lib/tcm_utils.rb
@@ -1,5 +1,5 @@
 class TcmUtils
-  RetrospectiveCutoffDate = Time.zone.parse("31-MAR-2018 23:59:59")
+  # RetrospectiveCutoffDate = Time.zone.parse("31-MAR-2018 23:59:59")
 
   def self.strip_bom(str)
     str.force_encoding('utf-8').gsub("\xEF\xBB\xBF".force_encoding('utf-8'), '')
@@ -82,6 +82,6 @@ class TcmUtils
   end
 
   def self.retrospective_date?(end_date)
-    end_date < RetrospectiveCutoffDate
+    end_date < SystemConfig.config.retrospective_cut_off_date
   end
 end

--- a/db/migrate/20180314084500_add_retrospective_cutoff_date_to_system_config.rb
+++ b/db/migrate/20180314084500_add_retrospective_cutoff_date_to_system_config.rb
@@ -1,0 +1,5 @@
+class AddRetrospectiveCutoffDateToSystemConfig < ActiveRecord::Migration[5.1]
+  def change
+    add_column :system_configs, :retrospective_cut_off_date, :datetime, null: false, default: '1-APR-2018 00:00:00'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180228104951) do
+ActiveRecord::Schema.define(version: 20180314084500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 20180228104951) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "process_retrospectives", default: true, null: false
+    t.datetime "retrospective_cut_off_date", default: "2018-04-01 00:00:00", null: false
   end
 
   create_table "transaction_details", force: :cascade do |t|


### PR DESCRIPTION
Added means to alter retrospective billing cutoff date so that last years billing files can be treated as current for testing. This is due to being unable to produce "future" test data in CFD and being unable to alter the system date on the test CFD system due to being on a shared platform.