### PR TITLE
Added blank pro-rata date

### DIFF
--- a/app/presenters/cfd_transaction_detail_presenter.rb
+++ b/app/presenters/cfd_transaction_detail_presenter.rb
@@ -18,7 +18,14 @@ class CfdTransactionDetailPresenter < TransactionDetailPresenter
   end
 
   def pro_rata_days
-    "#{billable_days}/#{financial_year_days}"
+    bd = billable_days
+    fyd = financial_year_days
+
+    if bd == fyd
+      ''
+    else
+      "#{bd}/#{fyd}"
+    end
   end
 
   def transaction_date

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -36,6 +36,12 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal("#{days[1]}/#{days[0]}", @presenter.pro_rata_days)
   end
 
+  def test_pro_rata_days_returns_empty_when_full_year
+    @transaction.period_start = Time.zone.parse('1-APR-2018 00:00:00')
+    @transaction.period_end = Time.zone.parse('31-MAR-2019 23:59:59')
+    assert_empty(@presenter.pro_rata_days)
+  end
+
   def test_it_returns_billable_days
     assert_equal(@presenter.billable_days, billable_days)
   end


### PR DESCRIPTION
Pro rata date should be blank when billable days matches financial year days.