### PR TITLE
Added test for zero variation handling from annual billing file

### DIFF
--- a/test/fixtures/files/cfd_abd_zero_variation.csv
+++ b/test/fixtures/files/cfd_abd_zero_variation.csv
@@ -1,0 +1,5 @@
+Consent Reference,Permit Category,Temporary Cessation,Variation
+ANQA/1234/1/1,2.3.4,Y,22
+ANNF/1754/1/1,2.3.4,N,0
+ZNNNF/1754/1/1,2.3.4,Y,84
+VP3839DA,2.4.4,N,100

--- a/test/services/annual_billing_data_file_service_test.rb
+++ b/test/services/annual_billing_data_file_service_test.rb
@@ -111,6 +111,24 @@ class AnnualBillingDataFileServiceTest < ActiveSupport::TestCase
     assert_equal(false, transaction_2.reload.temporary_cessation)
   end
 
+  def test_import_handles_zero_variation
+    file = file_fixture('cfd_abd_zero_variation.csv')
+    upload = prepare_upload(file)
+
+    transaction = transaction_details(:cfd)
+    transaction_2 = transaction.dup
+    transaction_2.reference_1 = "ANNF/1754/1/1"
+    transaction_2.save
+    transaction_3 = transaction.dup
+    transaction_3.reference_1 = "ZNNNF/1754/1/1"
+    transaction_3.save
+
+    @service.import(upload, file)
+    assert_equal("22%", transaction.reload.variation)
+    assert_equal("0%", transaction_2.reload.variation)
+    assert_equal("84%", transaction_3.reload.variation)
+  end
+
   def test_import_stores_variation_with_an_percent_suffix
     file = file_fixture('cfd_abd.csv')
     upload = prepare_upload(file)


### PR DESCRIPTION
Added a test to represent the (possible) issue of a zero '0' variation being specified in an annual billing csv data file causing an exception and preventing the import from completing.  The test passes without any code modification as I think this issue has been resolved by other dev work.