### PR TITLE
Fix for ordering variation

### DIFF
--- a/app/services/transaction_file_importer.rb
+++ b/app/services/transaction_file_importer.rb
@@ -91,6 +91,9 @@ class TransactionFileImporter
     elsif regime.water_quality?
       consent_parts = extract_consent_fields(row[Detail::LineDescription])
       data.merge!(consent_parts) unless consent_parts.empty?
+      data.merge!({
+        variation: extract_variation(row)
+      })
     elsif regime.waste?
       line = row[Detail::LineDescription]
       data.merge!({
@@ -154,6 +157,15 @@ class TransactionFileImporter
       }
     end
     parts
+  end
+
+  def extract_variation(row)
+    v = row[Detail::LineAttr9]
+    if v.blank?
+      "100%"
+    else
+      "#{v}%"
+    end
   end
 
   def determine_financial_year(date)

--- a/app/services/transaction_storage_service.rb
+++ b/app/services/transaction_storage_service.rb
@@ -90,6 +90,8 @@ class TransactionStorageService
 
   def order_query(q, col, dir)
     dir = dir == 'desc' ? :desc : :asc
+    txt_dir = (dir == :asc) ? 'asc' : 'desc'
+
     # lookup col value
     case col.to_sym
     when :customer_reference
@@ -112,8 +114,10 @@ class TransactionStorageService
       q.order(category: dir, id: dir)
     when :compliance_band
       q.order(line_attr_11: dir, id: dir)
+    # when :variation
+    #   q.order(line_attr_9: dir, id: dir)
     when :variation
-      q.order(line_attr_9: dir, id: dir)
+      q.order("to_number(variation, '999%') #{txt_dir}")
     when :period
       q.order(period_start: dir, period_end: dir, id: dir)
     when :tcm_transaction_reference

--- a/test/services/transaction_file_importer_test.rb
+++ b/test/services/transaction_file_importer_test.rb
@@ -46,6 +46,12 @@ class TransactionFileImporterTest < ActiveSupport::TestCase
     end
   end
 
+  def test_populates_variation_field
+    @header.transaction_details.each do |transaction|
+      assert_not_nil(transaction.variation)
+    end
+  end
+
   def test_imported_transactions_have_default_temporary_cessation_value
     @header.transaction_details.each do |transaction|
       assert_equal(false, transaction.temporary_cessation)


### PR DESCRIPTION
Variation is a text field that contains a percentage value (e.g. '86%') or is blank (representing '100%').
To be able to sort on this column requires it to be converted to a number first. Also the value is held in an additional `:variation` attribute if it is updated via the annual billing data file import (so we preserve the original value).  This fix copies the original value to the `:variation` attribute on import so that it is always the field to reference and also changes the order query clause to convert this value to a number in the SQL statement.