### PR TITLE
Fixed issue with changing page size when on last page

### DIFF
--- a/app/javascript/components/TransactionsView.jsx
+++ b/app/javascript/components/TransactionsView.jsx
@@ -123,7 +123,19 @@ export default class TransactionsView extends React.Component {
   }
 
   changePageSize (size) {
-    this.setState({pageSize: size}, () => {
+    // need to ensure we don't fall off the end into no-man's land by being on
+    // the last page and making the page size larger
+    const pagination = this.state.transactions.pagination
+    const total = pagination.total_count
+    const pageSize = this.state.pageSize
+    let currentPage = this.state.currentPage
+    const numPages = (total / size) + 1
+
+    if (numPages < currentPage) {
+      currentPage = Math.max(1, numPages)
+    }
+
+    this.setState({pageSize: size, currentPage: currentPage}, () => {
       this.fetchTableData()
     })
   }


### PR DESCRIPTION
When on final page of results and the user increases the page size, when the results are reloaded the user can end up in a no-man's land outside the range of pages available and pagination summary is thrown out e.g. `Displaying 6851 - 2753 of 2753 matching entries`.
This fixes this by adjusting the `currentPage` as necessary when the page size is changed. 