### PR TITLE
Fixed issue in JSON query

### DIFF
--- a/app/models/transaction_detail.rb
+++ b/app/models/transaction_detail.rb
@@ -13,7 +13,7 @@ class TransactionDetail < ApplicationRecord
   scope :historic, -> { where(status: 'billed') }
 
   scope :with_charge_errors, -> {
-    where("charge_calculation -> 'calculation' ->> 'messages' is not null")
+    where("(charge_calculation -> 'calculation' ->> 'messages') is not null")
   }
   scope :credits, -> { where(arel_table[:line_amount].lt 0) }
   scope :invoices, -> { where(arel_table[:line_amount].gteq 0) }


### PR DESCRIPTION
Fixed issue with JSON query `is not null` requiring brackets around the JSON selector part.