### PR TITLE
Fixed issue with 100% variation should be exported as an empty string

### DIFF
--- a/app/presenters/cfd_transaction_detail_presenter.rb
+++ b/app/presenters/cfd_transaction_detail_presenter.rb
@@ -26,6 +26,12 @@ class CfdTransactionDetailPresenter < TransactionDetailPresenter
     variation || line_attr_9
   end
 
+  def variation_percentage_file
+    val = variation_percentage
+    return "" if val == '100%'
+    val
+  end
+
   def consent_reference
     reference_1
     # "#{permit_reference}/#{version}/#{discharge_reference}"

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -72,8 +72,21 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal(@presenter.clean_variation_percentage, clean_variation)
   end
 
-  def test_it_returns_variation_percentage
-    assert_equal(@presenter.variation_percentage, @transaction.line_attr_9)
+  def test_variation_percentage_when_not_updated_is_original_value
+    @presenter.line_attr_9 = "95%"
+    @presenter.variation = nil
+    assert_equal("95%", @presenter.variation_percentage)
+  end
+
+  def test_variation_percentage_when_updated_is_new_value
+    @presenter.line_attr_9 = "95%"
+    @presenter.variation = "24%"
+    assert_equal("24%", @presenter.variation_percentage)
+  end
+
+  def test_variation_percentage_file_returns_blank_when_100
+    @presenter.variation = "100%"
+    assert_equal("", @presenter.variation_percentage_file) 
   end
 
   def test_it_returns_consent_reference
@@ -116,7 +129,7 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
       tcm_transaction_reference: @presenter.tcm_transaction_reference,
       generated_filename: @presenter.generated_filename,
       original_filename: @presenter.original_filename,
-      original_file_date: @presenter.original_file_date,
+      original_file_date: @presenter.original_file_date_table,
       consent_reference: @presenter.consent_reference,
       version: @presenter.version,
       discharge: @presenter.discharge_reference,

--- a/test/presenters/pas_transaction_detail_presenter_test.rb
+++ b/test/presenters/pas_transaction_detail_presenter_test.rb
@@ -46,7 +46,7 @@ class PasTransactionDetailPresenterTest < ActiveSupport::TestCase
         tcm_transaction_reference: @presenter.tcm_transaction_reference,
         generated_filename: @presenter.generated_filename,
         original_filename: @presenter.original_filename,
-        original_file_date: @presenter.original_file_date,
+        original_file_date: @presenter.original_file_date_table,
         permit_reference: @presenter.permit_reference,
         original_permit_reference: @presenter.original_permit_reference,
         compliance_band: @presenter.compliance_band,
@@ -57,7 +57,8 @@ class PasTransactionDetailPresenterTest < ActiveSupport::TestCase
         region: @presenter.region_from_ref,
         period: @presenter.period,
         line_amount: @presenter.original_charge,
-        amount: @presenter.amount
+        amount: @presenter.amount,
+        error_message: @presenter.error_message
       },
       @presenter.as_json
     )

--- a/test/presenters/wml_transaction_detail_presenter_test.rb
+++ b/test/presenters/wml_transaction_detail_presenter_test.rb
@@ -31,7 +31,7 @@ class WmlTransactionDetailPresenterTest < ActiveSupport::TestCase
   end
 
   def test_it_transforms_into_json
-    assert_equal(@presenter.as_json, {
+    assert_equal({
       id: @transaction.id,
       customer_reference: @presenter.customer_reference,
       permit_reference: @presenter.permit_reference,
@@ -40,7 +40,7 @@ class WmlTransactionDetailPresenterTest < ActiveSupport::TestCase
       temporary_cessation: @presenter.temporary_cessation_flag,
       period: @presenter.period,
       amount: @presenter.amount,
-      errors: nil
-    })
+      error_message: nil
+    }, @presenter.as_json)
   end
 end


### PR DESCRIPTION
In CFD, the variation value can be overridden by the annual billing data file (ABDF) import.  The rule here is that if a value is blank in the ABDF it is ignored.  If a variation of 100% (which is normally represented with an empty string) is included it is being exported as "100%" in a generated transaction file.  What should happen is that we set the variation value to "100%" and handle what to display in the presenters (100% on screen, blank in transaction files).