### PR TITLE
Fixed issue with discharge location prefix

### DIFF
--- a/app/presenters/cfd_transaction_detail_presenter.rb
+++ b/app/presenters/cfd_transaction_detail_presenter.rb
@@ -58,7 +58,7 @@ class CfdTransactionDetailPresenter < TransactionDetailPresenter
   end
 
   def discharge_location
-    "Discharge Location: #{site}" unless site.blank?
+    "Discharge Location: #{site}"
   end
 
   # def period

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -122,6 +122,16 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal('', @presenter.temporary_cessation_file)
   end
 
+  def test_discharge_location_has_correct_prefix
+    val = "Discharge Location: #{@transaction.line_attr_1}"
+    assert_equal(val, @presenter.discharge_location)
+  end
+
+  def test_discharge_location_has_prefix_when_blank
+    @presenter.line_attr_1 = nil
+    assert_equal("Discharge Location: ", @presenter.discharge_location)
+  end
+
   def test_it_transforms_into_json
     assert_equal({
       id: @transaction.id,


### PR DESCRIPTION
The `:line_description` field cannot be blank in the output transaction files.  This is a change to the original spec. We build this value using the static prefix 'Discharge Location: ' and the value from `:line_attr_1` which _could_ be blank in the source file.  The agreed solution is to just keep the prefix string when the `:line_attr_1` value is actually blank.