### PR TITLE
Added transaction exclusion functionality

### DIFF
--- a/app/assets/stylesheets/transactions.scss
+++ b/app/assets/stylesheets/transactions.scss
@@ -1,3 +1,5 @@
+$text-col: theme-color("dark");
+
 .transaction-summary {
   // dt:after {
   //   content: ":";
@@ -40,4 +42,23 @@
 
 .error-popup a {
   color: #660000;
+}
+
+.exclude-button {
+  margin-top: 0.75em;
+  margin-left: 0;
+}
+
+tr.excluded {
+  color: #aaa;
+  text-decoration: line-through;
+}
+
+.excluded tr.excluded {
+  color: $text-col;
+  text-decoration: none;
+}
+
+.exclude-button:checked {
+  margin-top: .25em;
 }

--- a/app/controllers/exclusion_reasons_controller.rb
+++ b/app/controllers/exclusion_reasons_controller.rb
@@ -1,0 +1,52 @@
+class ExclusionReasonsController < AdminController
+  include RegimeScope
+  before_action :set_regime
+  before_action :set_reason, only: [:edit, :update, :destroy]
+
+  def index
+    @reasons = @regime.exclusion_reasons.order(:reason)
+  end
+
+  def show
+  end
+
+  def new
+    @reason = @regime.exclusion_reasons.build
+  end
+
+  def create
+    @reason = @regime.exclusion_reasons.new(reason_params)
+
+    if @reason.valid?
+      @reason.save!
+      redirect_to regime_exclusion_reasons_path(@regime), notice: 'Exclusion reason created'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @reason.update(reason_params)
+      redirect_to regime_exclusion_reasons_path(@regime), notice: 'Exclusion reason updated'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @reason.destroy
+    redirect_to regime_exclusion_reasons_path(@regime), notice: 'Exclusion reason deleted'
+  end
+
+private
+  def set_reason
+    @reason = @regime.exclusion_reasons.find(params[:id])
+  end
+
+  def reason_params
+    params.require(:exclusion_reason).permit(:reason, :active)
+  end
+end

--- a/app/controllers/exclusions_controller.rb
+++ b/app/controllers/exclusions_controller.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class ExclusionsController < ApplicationController
+  include RegimeScope
+  before_action :set_regime, only: [:index]
+  before_action :set_transaction, only: [:show]
+
+  # GET /regimes/:regime_id/exclusions
+  # GET /regimes/:regime_id/exclusions.json
+  def index
+    regions = transaction_store.exclusion_regions
+    @region = params.fetch(:region, '')
+    @region = regions.first unless @region.blank? || regions.include?(@region)
+
+    respond_to do |format|
+      format.html do
+        render
+      end
+      format.js
+      format.json do
+        q = params.fetch(:search, "")
+        fy = params.fetch(:fy, '')
+        pg = params.fetch(:page, 1)
+        per_pg = params.fetch(:per_page, 10)
+
+        @transactions = transaction_store.excluded_transactions(
+          q,
+          fy,
+          pg,
+          per_pg,
+          @region,
+          params.fetch(:sort, :customer_reference),
+          params.fetch(:sort_direction, 'asc'))
+
+        financial_years = transaction_store.exclusion_financial_years.reject { |r| r.blank? }
+        @transactions = present_transactions(@transactions, @region, regions, financial_years)
+        render json: @transactions
+      end
+    end
+  end
+
+  # GET /regimes/:regime_id/exclusions/1
+  # GET /regimes/:regime_id/exclusions/1.json
+  def show
+  end
+
+  private
+    def present_transactions(transactions, selected_region, regions, financial_years)
+      name = "#{@regime.slug}_transaction_detail_presenter".camelize
+      presenter = str_to_class(name) || TransactionDetailPresenter
+      arr = Kaminari.paginate_array(presenter.wrap(transactions),
+                                    total_count: transactions.total_count,
+                                    limit: transactions.limit_value,
+                                    offset: transactions.offset_value)
+      {
+        pagination: {
+          current_page: arr.current_page,
+          prev_page: arr.prev_page,
+          next_page: arr.next_page,
+          per_page: arr.limit_value,
+          total_pages: arr.total_pages,
+          total_count: arr.total_count
+        },
+        transactions: arr,
+        selected_region: selected_region,
+        regions: region_options(regions),
+        financial_years: financial_year_options(financial_years)
+      }
+    end
+
+    def region_options(regions)
+      opts = regions.map { |r| { label: r, value: r } }
+      opts = [{label: 'All', value: ''}] + opts if opts.count > 1
+      opts
+    end
+
+    def financial_year_options(fy_list)
+      fys = fy_list.map { |fy| { label: fy[0..1] + '/' + fy[2..3], value: fy } }
+      fys = [{label: 'All', value: ''}] + fys if fys.count > 1
+      fys
+    end
+
+    def transaction_store
+      @transaction_store ||= TransactionStorageService.new(@regime)
+    end
+end

--- a/app/javascript/components/ExclusionReasonDialog.jsx
+++ b/app/javascript/components/ExclusionReasonDialog.jsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import OptionSelector from './OptionSelector'
+
+export default class ExclusionReasonDialog extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      callbackFired: false
+    }
+    this.close = this.close.bind(this)
+    this.onCancel = this.onCancel.bind(this)
+    this.onChangeReason = this.onChangeReason.bind(this)
+    this.onExcludeTransaction = this.onExcludeTransaction.bind(this)
+  }
+
+  onChangeReason (ev) {
+    const val = ev.target.value
+    // triggering re-rendering breaks something between the DOM and react
+    // and you cannot close the dialog
+    // ... so we don't set a state value here
+  }
+
+  onExcludeTransaction () {
+    const reason = $(this.reasonSelect).val()
+    $(this.dialog).off('hide.bs.modal', this.onCancel)
+    $(this.dialog).modal('hide')
+    $(this.dialog).on('hide.bs.modal', this.onCancel)
+    this.props.onSave(reason)
+  }
+
+  onCancel (ev) {
+    if (ev.type === 'hide') {
+      this.props.onClose()
+    } else {
+      $(this.dialog).modal('hide')
+    }
+  }
+
+  close () {
+    $(this.dialog).modal('hide')
+    this.props.onClose()
+  }
+
+  componentDidMount () {
+    $(this.dialog).on('hide.bs.modal', this.onCancel)
+  }
+
+  componentWillUnmount () {
+    $(this.dialog).off('hide.bs.modal', this.onCancel)
+  }
+
+  componentDidUpdate () {
+    $(this.dialog).modal({
+      show: this.props.show
+    })
+  }
+
+  render () {
+    const id = this.props.id
+    const reasons = this.props.reasons
+    const title = this.props.title
+    const buttonLabel = this.props.buttonLabel
+    const disabled = reasons.length === 0
+
+    const options = reasons.map((item, i) => {
+      return (<option key={i} value={item.reason}>{item.reason}</option>)
+    })
+
+    return (
+      <div id={id} className='modal fade' tabIndex='-1' role='dialog'
+        data-backdrop='static' aria-hidden='true' ref={el => this.dialog = el}>
+        <div className='modal-dialog' role='document'>
+          <div className='modal-content'>
+            <div className='modal-header'>
+              <h5 className='modal-title'>{title}</h5>
+              <button type='button' className='close'
+                onClick={this.onCancel}
+                aria-label='Close'>
+                <span aria-hidden='true'>&times;</span>
+              </button>
+            </div>
+            <div className='modal-body'>
+              <div className='row'>
+                <div className='col'>
+                  <h6 className='heading-small' id='reason-label'>
+                    Select the reason for excluding this transaction
+                  </h6>
+                </div>
+              </div>
+              <div className='row'>
+                <div className='col'>
+                  <div className='panel'>
+                    <select
+                      ref={el => this.reasonSelect = el}
+                      className='form-control'
+                      name='reason-selector'
+                      id='reason-selector'
+                      aria-labelledby='reason-label'
+                      onChange={this.onChangeReason}
+                    >
+                      {options}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className='modal-footer'>
+              <button className='btn btn-primary'
+                ref={el => this.saveBtn = el}
+                disabled={disabled}
+                onClick={this.onExcludeTransaction}>
+                Exclude Transaction
+              </button>
+              <button type='button' className='btn btn-secondary'
+                onClick={this.onCancel}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/javascript/components/TransactionSummary.jsx
+++ b/app/javascript/components/TransactionSummary.jsx
@@ -37,6 +37,18 @@ export default class TransactionSummary extends React.Component {
     const csrfToken = this.props.csrfToken
     const title = this.props.title
     const buttonLabel = this.props.buttonLabel
+    const excluded = summary.excluded_count
+
+    let excludedWarning = null
+    if (excluded > 0) {
+      excludedWarning = (
+        <div className='row alert alert-warning'>
+          <div className='col'>
+            Proceeding will remove <strong>{excluded}</strong> excluded transaction{excluded > 1 ? 's' : ''}
+          </div>
+        </div>
+      )
+    }
 
     return (
       <form method='post' action={action}>
@@ -77,6 +89,7 @@ export default class TransactionSummary extends React.Component {
                   </div>
                 </div>
               </div>
+              {excludedWarning}
             </div>
             <div className='modal-footer'>
               <input type='submit' className='btn btn-primary' disabled={disabled}

--- a/app/javascript/components/TransactionTable.jsx
+++ b/app/javascript/components/TransactionTable.jsx
@@ -1,8 +1,57 @@
 import React from 'react'
 import TransactionTableHeader from './TransactionTableHeader'
-import TransactionTableBody from './TransactionTableBody'
+// import TransactionTableBody from './TransactionTableBody'
+import TransactionTableRow from './TransactionTableRow'
+import ExclusionReasonDialog from './ExclusionReasonDialog'
 
 export default class TransactionTable extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      exclusionDialogOpen: false
+    }
+
+    this.showExclusionDialog = this.showExclusionDialog.bind(this)
+    this.onCancelExclusionDialog = this.onCancelExclusionDialog.bind(this)
+    this.onSaveExclusionReason = this.onSaveExclusionReason.bind(this)
+  }
+
+  showExclusionDialog (saveCallback, cancelCallback) {
+    console.log('show dialog')
+    this.setState({
+      exclusionDialogOpen: true,
+      saveCallback: saveCallback,
+      cancelCallback: cancelCallback
+    })
+  }
+
+  onCancelExclusionDialog () {
+    console.log('cancel dialog')
+    const cancelFn = this.state.cancelCallback
+    if (cancelFn) {
+      cancelFn()
+    }
+    this.setState({
+      exclusionDialogOpen: false,
+      saveCallback: null,
+      cancelCallback: null
+    })
+  }
+
+  onSaveExclusionReason(reason) {
+    console.log('onSaveExclusionReason: ' + reason)
+    const saveFn = this.state.saveCallback
+    if (saveFn) {
+      saveFn(reason)
+    }
+    this.setState({
+      exclusionDialogOpen: false,
+      saveCallback: null,
+      cancelCallback: null
+    })
+  }
+
   render () {
     const columns = this.props.columns
     const sortCol = this.props.sortColumn
@@ -14,7 +63,37 @@ export default class TransactionTable extends React.Component {
     const onChangeCategory = this.props.onChangeCategory
     const onChangeTemporaryCessation = this.props.onChangeTemporaryCessation
 
+    let exclusionReasonDialog = null
+
+    if (this.props.canExcludeTransactions) {
+      exclusionReasonDialog = (
+        <ExclusionReasonDialog id='exclusion-dialog'
+          show={this.state.exclusionDialogOpen}
+          reasons={this.props.exclusionReasons}
+          title='Exclude Transaction'
+          buttonLabel='Exclude Transaction'
+          onSave={this.onSaveExclusionReason}
+          onClose={this.onCancelExclusionDialog}
+        />
+      )
+    }
+
+    const rows = this.props.data.map((r) =>
+      <TransactionTableRow
+        key={r.id}
+        columns={columns}
+        row={r}
+        categories={categories}
+        onChangeCategory={onChangeCategory}
+        onChangeTemporaryCessation={onChangeTemporaryCessation}
+        onShowExclusionDialog={this.showExclusionDialog}
+        onExcludeTransaction={this.props.onExcludeTransaction}
+        onReinstateTransaction={this.props.onReinstateTransaction}
+      />)
+
     return (
+      <div>
+        {exclusionReasonDialog}
       <table className='table table-responsive'>
         <TransactionTableHeader
           columns={columns}
@@ -23,14 +102,24 @@ export default class TransactionTable extends React.Component {
           onChangeSortDirection={onSortDirChange}
           onChangeSortColumn={onSortColChange}
         />
+        <tbody>
+          {rows}
+        </tbody>
+      </table>
+    </div>
+    )
+  }
+}
+/*
         <TransactionTableBody
           columns={columns}
           data={data}
           categories={categories}
           onChangeCategory={onChangeCategory}
           onChangeTemporaryCessation={onChangeTemporaryCessation}
+          onShowExclusionDialog={this.showExclusionDialog}
+          onReinstateTransaction={this.onReinstateExcludedTransaction}
+          excludeTransaction={this.props.excludeTransaction}
+          reinstateTransaction={this.props.reinstateTransaction}
         />
-      </table>
-    )
-  }
-}
+*/

--- a/app/javascript/components/TransactionTableBody.jsx
+++ b/app/javascript/components/TransactionTableBody.jsx
@@ -16,6 +16,9 @@ export default class TransactionTableBody extends React.Component {
         categories={categories}
         onChangeCategory={onChangeCategory}
         onChangeTemporaryCessation={onChangeTemporaryCessation}
+        onExclusionSave={this.props.onExclusionSave}
+        onShowExclusionDialog={this.props.onShowExclusionDialog}
+        onReinstateTransaction={this.props.onReinstateTransaction}
       />)
 
     return (

--- a/app/javascript/components/TransactionTableHeader.jsx
+++ b/app/javascript/components/TransactionTableHeader.jsx
@@ -19,12 +19,20 @@ export default class TransactionTableHeader extends React.Component {
     )
     return (
       <thead>
-        <tr>{cols}<td /></tr>
+        <tr>{cols}<td key='options' /></tr>
       </thead>
     )
   }
 
   columnMarkup (col) {
+    if (col.name === 'excluded') {
+      if (col.editable) {
+        return <td key={col.name}/>
+      } else {
+        return ''
+      }
+    }
+    
     if (col.sortable) {
       const selected = this.selectionInfo(col)
       return (

--- a/app/javascript/components/constants.js
+++ b/app/javascript/components/constants.js
@@ -4,7 +4,15 @@ const Constants = module.exports = {}
 
 Constants.PAS_COLUMNS = { 
   unbilled: [
-    { name: 'original_filename',
+    {
+      name: 'excluded',
+      label: '',
+      accessHelp: 'transaction for Permit ',
+      accessHelpColumn: 'permit_reference',
+      sortable: false,
+      editable: true
+    }, {
+      name: 'original_filename',
       label: 'File Reference',
       sortable: true,
       editable: false
@@ -153,12 +161,68 @@ Constants.PAS_COLUMNS = {
       editable: false,
       rightAlign: true
     }
+  ],
+  excluded: [
+    { name: 'original_filename',
+      label: 'File Reference',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'original_file_date',
+      label: 'File Date',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'customer_reference',
+      label: 'Customer',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'permit_reference',
+      label: 'Permit',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'original_permit_reference',
+      label: 'Original Permit',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'compliance_band',
+      label: 'Compliance Band',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'period',
+      label: 'Period',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'excluded_reason',
+      label: 'Exclusion Reason',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'amount',
+      label: 'Credit/Invoice',
+      sortable: false,
+      editable: false,
+      rightAlign: true
+    }
   ]
 }
 
 Constants.CFD_COLUMNS = {
   unbilled: [
-    { name: 'original_filename',
+    {
+      name: 'excluded',
+      label: '',
+      accessHelp: 'transaction for Consent Reference ',
+      accessHelpColumn: 'consent_reference',
+      sortable: false,
+      editable: true
+    }, {
+      name: 'original_filename',
       label: 'File Reference',
       sortable: true,
       editable: false
@@ -342,12 +406,69 @@ Constants.CFD_COLUMNS = {
       editable: false,
       rightAlign: true
     }
+  ],
+  excluded: [
+    { name: 'original_filename',
+      label: 'File Reference',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'original_file_date',
+      label: 'File Date',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'customer_reference',
+      label: 'Customer',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'consent_reference',
+      label: 'Consent',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'version',
+      label: 'Ver',
+      accessLabel: 'Version',
+      sortable: false,
+      editable: false
+    }, {
+      name: 'discharge',
+      label: 'Dis',
+      accessLabel: 'Discharge',
+      sortable: false,
+      editable: false
+    }, {
+      name: 'variation',
+      label: '%',
+      accessLabel: 'Variation Percentage',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'period',
+      label: 'Period',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'excluded_reason',
+      label: 'Exclusion Reason',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'amount',
+      label: 'Credit/Invoice',
+      sortable: false,
+      editable: false,
+      rightAlign: true
+    }
   ]
 }
 
 Constants.WML_COLUMNS = {
   unbilled: [
-    { name: 'original_filename',
+    {
+      name: 'original_filename',
       label: 'File Reference',
       sortable: true,
       editable: false
@@ -486,6 +607,39 @@ Constants.WML_COLUMNS = {
       editable: false,
       rightAlign: true
     }
+  ],
+  excluded: [
+    { name: 'customer_reference',
+      label: 'Customer',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'permit_reference',
+      label: 'Permit',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'compliance_band',
+      label: 'Compliance Band',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'period',
+      label: 'Period',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'excluded_reason',
+      label: 'Exclusion Reason',
+      sortable: true,
+      editable: false
+    }, {
+      name: 'amount',
+      label: 'Credit/Invoice',
+      sortable: false,
+      editable: false,
+      rightAlign: true
+    }
   ]
 }
 
@@ -505,7 +659,8 @@ Constants.DATA_FILE_COLUMNS = [
 Constants.VIEW_MODE_NAMES = [
   'unbilled',
   'historic',
-  'retrospective'
+  'retrospective',
+  'excluded'
 ]
 
 Constants.VIEW_MODES = {
@@ -527,6 +682,11 @@ Constants.VIEW_MODES = {
     path: '/retrospectives',
     summaryPath: '/retrospective_summary',
     generatePath: '/retrospective_files'
+  },
+  excluded: {
+    name: 'excluded',
+    label: 'Excluded transactions',
+    path: '/exclusions'
   }//,
   // { name: 'retrospective_history',
   //   label: 'Retrospective History',

--- a/app/lib/transaction_group_filters.rb
+++ b/app/lib/transaction_group_filters.rb
@@ -5,7 +5,7 @@ module TransactionGroupFilters
   end
 
   def grouped_unbilled_transactions_by_region(region)
-    regime_specific_group_filter(unbilled_transactions.region(region))
+    regime_specific_group_filter(unbilled_transactions.region(region).unexcluded)
   end
 
   def grouped_retrospective_transactions_by_region(region)
@@ -16,12 +16,20 @@ module TransactionGroupFilters
     retrospective_transactions.region(region)
   end
 
+  def excluded_transactions_by_region(region)
+    excluded_transactions.region(region)
+  end
+
   def unbilled_transactions
     regime.transaction_details.unbilled
   end
 
   def retrospective_transactions
     regime.transaction_details.retrospective
+  end
+
+  def excluded_transactions
+    regime.transaction_details.excluded
   end
 
   def regime_specific_group_filter(base_query)

--- a/app/models/exclusion_reason.rb
+++ b/app/models/exclusion_reason.rb
@@ -1,0 +1,5 @@
+class ExclusionReason < ApplicationRecord
+  belongs_to :regime, inverse_of: :exclusion_reasons
+
+  validates :reason, presence: true, uniqueness: { scope: :regime_id }
+end

--- a/app/models/regime.rb
+++ b/app/models/regime.rb
@@ -6,6 +6,7 @@ class Regime < ApplicationRecord
   has_many :permit_categories, inverse_of: :regime, dependent: :destroy
   has_many :transaction_files, inverse_of: :regime, dependent: :destroy
   has_many :annual_billing_data_files, inverse_of: :regime, dependent: :destroy
+  has_many :exclusion_reasons, inverse_of: :regime, dependent: :destroy
 
   has_many :regime_users, inverse_of: :regime, dependent: :destroy
   has_many :users, through: :regime_users

--- a/app/models/transaction_detail.rb
+++ b/app/models/transaction_detail.rb
@@ -6,7 +6,9 @@ class TransactionDetail < ApplicationRecord
                      :temporary_cessation,
                      :charge_calculation,
                      :tcm_charge,
-                     :variation ]
+                     :variation,
+                     :excluded,
+                     :excluded_reason ]
 
   belongs_to :transaction_header, inverse_of: :transaction_details
   has_one :regime, through: :transaction_header
@@ -20,6 +22,12 @@ class TransactionDetail < ApplicationRecord
   scope :unbilled, -> { where(status: 'unbilled') }
   scope :retrospective, -> { where(status: 'retrospective') }
   scope :historic, -> { where(status: 'billed') }
+
+  scope :excluded, -> { where(excluded: true) }
+  scope :unexcluded, -> { where(excluded: false) }
+  scope :historic_excluded, -> { where(status: 'excluded') }
+
+  scope :unbilled_exclusions, -> { where(status: 'unbilled', excluded: true) }
 
   scope :with_charge_errors, -> {
     where("(charge_calculation -> 'calculation' ->> 'messages') is not null")
@@ -56,6 +64,16 @@ class TransactionDetail < ApplicationRecord
     where(arel_table[:customer_reference].matches(m).
           or(arel_table[:reference_1].matches(m)).
           or(arel_table[:transaction_reference].matches(m)))
+  end
+
+  def self.exclusion_search(q)
+    m = "%#{q}%"
+    where(arel_table[:customer_reference].matches(m).
+          or(arel_table[:reference_1].matches(m)).
+          or(arel_table[:reference_2].matches(m)).
+          or(arel_table[:transaction_reference].matches(m)).
+          or(arel_table[:original_filename].matches(m)).
+          or(arel_table[:excluded_reason].matches(m)))
   end
 
   def updateable?

--- a/app/presenters/cfd_transaction_detail_presenter.rb
+++ b/app/presenters/cfd_transaction_detail_presenter.rb
@@ -84,6 +84,8 @@ class CfdTransactionDetailPresenter < TransactionDetailPresenter
       period: period,
       line_amount: original_charge,
       amount: amount,
+      excluded: excluded,
+      excluded_reason: excluded_reason,
       error_message: error_message
     }
   end

--- a/app/presenters/pas_transaction_detail_presenter.rb
+++ b/app/presenters/pas_transaction_detail_presenter.rb
@@ -102,6 +102,8 @@ class PasTransactionDetailPresenter < TransactionDetailPresenter
       period: period,
       line_amount: original_charge,
       amount: amount,
+      excluded: excluded,
+      excluded_reason: excluded_reason,
       error_message: error_message
     }
   end

--- a/app/presenters/transaction_detail_presenter.rb
+++ b/app/presenters/transaction_detail_presenter.rb
@@ -151,11 +151,14 @@ class TransactionDetailPresenter < SimpleDelegator
   end
 
   def credit_debit
-    if line_amount.negative?
-      'Credit (TBC)'
-    else
-      'Invoice (TBC)'
-    end
+    txt = if line_amount.negative?
+            'Credit'
+          else
+            'Invoice'
+          end
+
+    txt += ' (TBC)' if status != 'excluded'
+    txt
   end
 
   def charge_amount

--- a/app/presenters/wml_transaction_detail_presenter.rb
+++ b/app/presenters/wml_transaction_detail_presenter.rb
@@ -78,6 +78,8 @@ class WmlTransactionDetailPresenter < TransactionDetailPresenter
       temporary_cessation: temporary_cessation_flag,
       period: period,
       amount: amount,
+      excluded: excluded,
+      excluded_reason: excluded_reason,
       error_message: error_message
     }
   end

--- a/app/services/transaction_file_exporter.rb
+++ b/app/services/transaction_file_exporter.rb
@@ -36,6 +36,8 @@ class TransactionFileExporter
         files << f
         # auditor.log_create(f)
       end
+      # 'remove' excluded transactions
+      excluded_transactions_by_region(region).update_all(status: 'excluded') 
     end
 
     # queue the background job to create the file

--- a/app/services/transaction_summary_service.rb
+++ b/app/services/transaction_summary_service.rb
@@ -14,7 +14,8 @@ class TransactionSummaryService
 
   def summarize(region)
     q = grouped_unbilled_transactions_by_region(region)
-    package_summary(q, :tcm_charge)
+    excluded = regime.transaction_details.region(region).unbilled_exclusions
+    package_summary(q, :tcm_charge, excluded)
   end
 
   def summarize_retrospectives(region)
@@ -23,18 +24,20 @@ class TransactionSummaryService
   end
 
 private
-  def package_summary(query, charge_field)
+  def package_summary(query, charge_field, excluded_query = nil)
     credits = query.credits.pluck(charge_field)
     invoices = query.invoices.pluck(charge_field)
     credit_total = credits.sum
     invoice_total = invoices.sum
+    excluded_count = excluded_query ? excluded_query.count : 0
 
     {
       credit_count:   credits.length,
       credit_total:   credit_total,
       invoice_count:  invoices.length,
       invoice_total:  invoice_total,
-      net_total:      invoice_total + credit_total
+      net_total:      invoice_total + credit_total,
+      excluded_count: excluded_count
     }
   end
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,5 +1,4 @@
 <h2><%= t "devise.invitations.new.header" %></h2>
-Wigwam
 <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
   <%#= devise_error_messages! %>
   <%= error_header(resource) %>

--- a/app/views/exclusion_reasons/_exclusion_reason.json.jbuilder
+++ b/app/views/exclusion_reasons/_exclusion_reason.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! exclusion_reason, :id, :reason

--- a/app/views/exclusion_reasons/_form.html.erb
+++ b/app/views/exclusion_reasons/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: [@regime, reason], local: true) do |form| %>
+  <%= error_header(reason) %>
+
+  <div class="col-lg-6">
+    <div class="form-group">
+      <%= form.label :reason, 'Reason' %>
+      <%= form.text_field :reason, id: :exclusion_reason_reason, class: "form-control" %>
+    </div>
+
+    <div class="actions mt-4">
+      <%= form.submit class: "btn btn-primary" %>
+      <%= link_to 'Back', regime_exclusion_reasons_path(@regime),
+        class: "btn btn-secondary", role: "button" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/exclusion_reasons/edit.html.erb
+++ b/app/views/exclusion_reasons/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col-8 mb-4">
+    <h1>Edit Exclusion Reason</h1>
+  </div>
+</div>
+<%= render 'form', reason: @reason %>
+

--- a/app/views/exclusion_reasons/index.html.erb
+++ b/app/views/exclusion_reasons/index.html.erb
@@ -1,0 +1,38 @@
+<div class="row">
+  <div class="col">
+    <h1 class="heading">Exclusion Reasons</h1>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Reason Description</th>
+          <td></td>
+        </tr>
+      </thead>
+      <tbody>
+        <% @reasons.each do |reason| %>
+          <tr>
+            <td><%= reason.reason %></td>
+            <td>
+              <%= link_to 'Edit',
+                edit_regime_exclusion_reason_path(@regime, reason),
+                class: 'btn btn-sm btn-success', role: 'button' %>
+              <%= link_to 'Delete',
+                regime_exclusion_reason_path(@regime, reason),
+                method: :delete, data: { confirm: 'Are you sure?' },
+                class: 'btn btn-sm btn-danger', role: 'button' %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <%= link_to 'New Exclusion Reason', new_regime_exclusion_reason_path(@regime),
+        class: 'btn btn-primary', role: 'button' %>
+  </div>
+</div

--- a/app/views/exclusion_reasons/index.json.jbuilder
+++ b/app/views/exclusion_reasons/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @reasons, partial: 'exclusion_reasons/exclusion_reason', as: :exclusion_reason

--- a/app/views/exclusion_reasons/new.html.erb
+++ b/app/views/exclusion_reasons/new.html.erb
@@ -1,0 +1,6 @@
+<div class="row">
+  <div class="col-8 mb-4">
+    <h1>New Exclusion Reason</h1>
+  </div>
+</div>
+<%= render 'form', reason: @reason %>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -4,7 +4,8 @@
       @regime = current_user.selected_regime
     end
 %>
-<nav class="main-menu navbar navbar-expand-lg navbar-dark bg-dark">
+<nav class="main-menu navbar navbar-expand-lg navbar-dark bg-dark"
+  data-turbolinks='false'>
   <%= link_to "Tactical Charging Module", root_path, class: "navbar-brand" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/app/views/shared/menu/_admin.html.erb
+++ b/app/views/shared/menu/_admin.html.erb
@@ -6,6 +6,9 @@
     <%= link_to "Permit Categories",
       regime_permit_categories_path(@regime),
       class: "dropdown-item", role: "menuitem" %>
+    <%= link_to "Exclusion Reasons",
+      regime_exclusion_reasons_path(@regime),
+      class: "dropdown-item", role: "menuitem" %>
     <div class="dropdown-divider"></div>
     <%= link_to "User Management",
       users_path, class: "dropdown-item", role: "menuitem" %>

--- a/app/views/shared/menu/_transactions.html.erb
+++ b/app/views/shared/menu/_transactions.html.erb
@@ -17,5 +17,8 @@
     <%= link_to "Retrospectives to be billed",
       regime_transactions_path(@regime, view_mode: 'retrospective'),
       class: "dropdown-item" %>
+    <%= link_to "Excluded Transactions",
+      regime_transactions_path(@regime, view_mode: 'excluded'),
+      class: "dropdown-item" %>
   </div>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,16 +15,17 @@ Rails.application.routes.draw do
     resources :transactions, only: [:index, :show, :edit, :update]
     resources :history, only: [:index, :show]
     resources :retrospectives, only: [:index, :show]
+    resources :exclusions, only: [:index]
     resources :transaction_files, only: [:create]
     resources :transaction_summary, only: [:index]
     resources :retrospective_files, only: [:create]
     resources :retrospective_summary, only: [:index]
     resources :annual_billing_data_files, except: [:destroy]
+    resources :exclusion_reasons, except: [:show]
   end
 
   root to: 'transactions#index'
 
-  # TODO: protect me when we add users
   require 'resque/server'
   authenticate(:user, ->(u) { u.admin? }) do
     mount Resque::Server, at: '/jobs'

--- a/db/migrate/20180501073149_create_exclusion_reasons.rb
+++ b/db/migrate/20180501073149_create_exclusion_reasons.rb
@@ -1,0 +1,12 @@
+class CreateExclusionReasons < ActiveRecord::Migration[5.1]
+  def change
+    create_table :exclusion_reasons do |t|
+      t.references :regime, index: true
+      t.string :reason, null: false
+      t.boolean :active, null: false, default: true
+      t.timestamps
+    end
+
+    add_index :exclusion_reasons, [:regime_id, :reason], unique: true
+  end
+end

--- a/db/migrate/20180504135421_add_exclusion_to_transaction_details.rb
+++ b/db/migrate/20180504135421_add_exclusion_to_transaction_details.rb
@@ -1,0 +1,7 @@
+class AddExclusionToTransactionDetails < ActiveRecord::Migration[5.1]
+  def change
+    add_column :transaction_details, :excluded, :boolean, null: false,
+      default: false, index: true
+    add_column :transaction_details, :excluded_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424113158) do
+ActiveRecord::Schema.define(version: 20180504135421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,16 @@ ActiveRecord::Schema.define(version: 20180424113158) do
     t.integer "line_number", null: false
     t.string "message", null: false
     t.index ["annual_billing_data_file_id"], name: "index_data_upload_errors_on_annual_billing_data_file_id"
+  end
+
+  create_table "exclusion_reasons", force: :cascade do |t|
+    t.bigint "regime_id"
+    t.string "reason", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["regime_id", "reason"], name: "index_exclusion_reasons_on_regime_id_and_reason", unique: true
+    t.index ["regime_id"], name: "index_exclusion_reasons_on_regime_id"
   end
 
   create_table "permit_categories", force: :cascade do |t|
@@ -190,6 +200,8 @@ ActiveRecord::Schema.define(version: 20180424113158) do
     t.string "original_filename"
     t.datetime "original_file_date"
     t.string "tcm_financial_year"
+    t.boolean "excluded", default: false, null: false
+    t.string "excluded_reason"
     t.index ["customer_reference"], name: "index_transaction_details_on_customer_reference"
     t.index ["sequence_number"], name: "index_transaction_details_on_sequence_number"
     t.index ["transaction_file_id"], name: "index_transaction_details_on_transaction_file_id"


### PR DESCRIPTION
Added the ability to select transactions from the _Transaction to be Billed_ view for exclusion from the bill run/generated files.  The transactions can be toggled between included/excluded until the transaction file is generated. At this point __all__ excluded transactions for the given regime/region are 'archived' and no longer visible on _Transactions to be Billed_. These archived transactions are visible on a new _Excluded Transactions_ view.