### PR TITLE
TTBB export shouldn't include excluded transactions

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -49,7 +49,7 @@ class TransactionsController < ApplicationController
           @region,
           sort_col,
           sort_dir
-        ).limit(15000)
+        ).unexcluded.limit(15000)
         send_data csv.export(presenter.wrap(@transactions)), csv_opts
       end
     end


### PR DESCRIPTION
Transactions marked as **excluded** shouldn't be in the exported transaction file generated from the _Transaction to be Billed_ view