### PR TITLE
Fixed retrospective file totals to use calculated transaction type

### DIFF
--- a/app/presenters/cfd_retrospective_file_presenter.rb
+++ b/app/presenters/cfd_retrospective_file_presenter.rb
@@ -48,10 +48,10 @@ class CfdRetrospectiveFilePresenter < CfdTransactionFilePresenter
   end
 protected
   def trailer_invoice_total
-    transaction_details.where(transaction_type: 'I').sum(:line_amount).to_i
+    transaction_details.where(tcm_transaction_type: 'I').sum(:line_amount).to_i
   end
 
   def trailer_credit_total
-    transaction_details.where(transaction_type: 'C').sum(:line_amount).to_i
+    transaction_details.where(tcm_transaction_type: 'C').sum(:line_amount).to_i
   end
 end


### PR DESCRIPTION
WQ Retrospective file trailer totals were grouped using original 'C' or 'I' `:transaction_type` rather than the `:tcm_transaction_type` calculated 'C' or 'I'. This would result in differences only when dealing with multiple input files that have transactions for the same `:customer_reference` with the same `:line_context_code`.