### PR TITLE
Wml ordering

### DIFF
--- a/app/lib/transaction_group_filters.rb
+++ b/app/lib/transaction_group_filters.rb
@@ -82,7 +82,7 @@ module TransactionGroupFilters
 
   def wml_sorter(base_query)
     # TODO: make this WML specific
-    base_query.order(transaction_reference: :asc,
+    base_query.order(tcm_transaction_reference: :asc,
                      reference_1: :asc,
                      line_amount: :asc)
   end

--- a/test/fixtures/transaction_files.yml
+++ b/test/fixtures/transaction_files.yml
@@ -27,3 +27,10 @@ pas_sroc_file:
   retrospective: false
   file_id: "50678T"
   generated_at: <%= 1.hour.ago %>
+
+wml_sroc_file:
+  regime: wml
+  region: 'B'
+  retrospective: false
+  file_id: "50012T"
+  generated_at: <%= 1.hour.ago %>

--- a/test/presenters/wml_transaction_file_presenter_test.rb
+++ b/test/presenters/wml_transaction_file_presenter_test.rb
@@ -1,0 +1,107 @@
+require 'test_helper.rb'
+
+class WmlTransactionFilePresenterTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:billing_admin)
+    Thread.current[:current_user] = @user
+
+    @transaction_1 = transaction_details(:wml)
+    @transaction_2 = @transaction_1.dup
+
+    @transaction_2.customer_reference ='A223344123P'
+    @transaction_2.transaction_reference ='E00555123'
+    @transaction_2.transaction_type = 'C'
+    @transaction_2.line_attr_2 = '012345'
+    @transaction_2.reference_1 = '012345'
+    @transaction_2.reference_2 = 'XZ3333PG/A001'
+    @transaction_2.line_amount = -1234
+    @transaction_2.unit_of_measure_price = -1234
+
+    [@transaction_1, @transaction_2].each_with_index do |t, i|
+      t.category = '2.4.4'
+      t.status = 'billed'
+      t.tcm_charge = t.line_amount
+      t.tcm_transaction_type = t.transaction_type
+      t.tcm_transaction_reference = generate_reference(t, 100 - i)
+      set_charge_calculation(t, "A(#{rand(50..100)}%)")
+    end
+
+    @file = transaction_files(:wml_sroc_file)
+    @file.transaction_details << @transaction_1
+    @file.transaction_details << @transaction_2
+
+    @presenter = WmlTransactionFilePresenter.new(@file)
+  end
+
+  def test_it_returns_a_header_record
+    assert_equal(
+      [
+        "H",
+        "0000000",
+        "WML",
+        "B",
+        "I",
+        @file.file_id,
+        "",
+        @file.generated_at.strftime("%-d-%^b-%Y")
+      ],
+      @presenter.header
+    )
+  end
+
+  def test_it_produces_detail_records
+    rows = []
+    @presenter.details do |row|
+      rows << row
+    end
+    assert_equal(2, rows.count)
+  end
+
+  def test_it_sorts_detail_rows_by_tcm_transaction_reference
+    rows = []
+    @presenter.details do |row|
+      rows << row
+    end
+    sorted_rows = [@transaction_1, @transaction_2].sort do |a,b|
+      a.tcm_transaction_reference <=> b.tcm_transaction_reference
+    end
+
+    rows.each_with_index do |r, i|
+      assert_equal(sorted_rows[i].tcm_transaction_reference, r[5])
+    end
+  end
+
+
+  def test_is_returns_a_trailer_record
+    count = @presenter.transaction_details.count
+    assert_equal(
+      [
+        "T",
+        (count + 1).to_s.rjust(7, '0'),
+        (count + 2).to_s.rjust(7, '0'),
+        @presenter.transaction_details.where(tcm_transaction_type: 'I').sum(:tcm_charge).to_i,
+        @presenter.transaction_details.where(tcm_transaction_type: 'C').sum(:tcm_charge).to_i
+      ],
+      @presenter.trailer
+    )
+  end
+
+  def set_charge_calculation(transaction, band)
+    transaction.charge_calculation = {
+      'calculation' => {
+        'chargeAmount' => transaction.tcm_charge.abs,
+        'compliancePerformanceBand' => band,
+        'decisionPoints' => {
+          'baselineCharge' => 196803,
+          'percentageAdjustment' => 0
+        }
+      },
+      'generatedAt' => '10-AUG-2017'
+    }
+    transaction.save!
+  end
+
+  def generate_reference(transaction, num)
+    "WML#{num.to_s.rjust(8, '0')}#{transaction.transaction_header.region}T"
+  end
+end


### PR DESCRIPTION
Spec was updated to include the ordering of transactions in the generated transaction files. Order should be based on the generated `:tcm_transaction_reference` (invoice number).