### PR TITLE
Added default exclusion reasons to seeds for PAS

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,16 @@ PermitCategoryImporter.import(r, Rails.root.join('db', 'categories', 'installati
   SequenceCounter.find_or_create_by(regime_id: r.id, region: region)
 end
 
+if r.exclusion_reasons.count.zero?
+  [
+    "Extra line auto-created by feeder system",
+    "Extra line created by PAS manual invoice function (permit category)",
+    "Extra line created by PAS manual invoice function (temporary cessation)"
+  ].each do |reason|
+    r.exclusion_reasons.create!(reason: reason, active: true)
+  end
+end
+
 r = Regime.find_by!(slug: 'cfd')
 r.permit_categories.destroy_all
 PermitCategoryImporter.import(r, Rails.root.join('db', 'categories', 'water_quality.csv'))


### PR DESCRIPTION
Added 3 default transaction exclusion reasons for the PAS regime to the seeds file. These will only be added if there are no existing exclusion reasons for the PAS regime when the `rake db:seed` task is invoked.