### PR TITLE
Fixed issue for billing admins where view not rendering

### DIFF
--- a/app/controllers/exclusion_reasons_controller.rb
+++ b/app/controllers/exclusion_reasons_controller.rb
@@ -1,5 +1,8 @@
 class ExclusionReasonsController < AdminController
   include RegimeScope
+  # allow billing admins access to the index (frontend JSON requests)
+  skip_before_action :admin_only_check!, only: :index
+
   before_action :set_regime
   before_action :set_reason, only: [:edit, :update, :destroy]
 


### PR DESCRIPTION
Fixed issue where access to exclusion reasons was behind the `:before_action` check for admins only. Billing admins also need to access the index method to retrieve the list of available reasons for exclusion. This could be moved out to an API layer in future instead.