### PR TITLE
Fix compliance band in WML files

### DIFF
--- a/app/presenters/wml_transaction_detail_presenter.rb
+++ b/app/presenters/wml_transaction_detail_presenter.rb
@@ -49,14 +49,16 @@ class WmlTransactionDetailPresenter < TransactionDetailPresenter
   end
 
   def compliance_band_with_percent
+    val = ""
     chg = transaction_detail.charge_calculation
     if !chg.nil? && !chg['calculation'].nil?
       band = chg['calculation']['compliancePerformanceBand']
       unless band.nil?
         d = band.match /\A(.*)(\(\d+%\))\z/
-        "#{d[1]} #{d[2]}" if d.size == 3
+        val = "#{d[1]} #{d[2]}" if d.size == 3 && d[1].strip.present?
       end
     end
+    val
   end
 
   def temporary_cessation_adjustment

--- a/test/controllers/exclusion_reasons_controller_test.rb
+++ b/test/controllers/exclusion_reasons_controller_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper.rb'
+
+class ExclusionReasonsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    sign_in users(:system_admin)
+    @regime = regimes(:cfd)
+    @reasons = @regime.exclusion_reasons.order(:reason)
+  end
+
+  def test_it_should_get_index_for_system_admin
+    get regime_exclusion_reasons_path(@regime)
+    assert_response :success
+    assert_equal @reasons, assigns(:reasons)
+  end
+
+  def test_it_should_get_new_for_system_admin
+    get new_regime_exclusion_reason_path(@regime)
+    assert_response :success
+    assert_not_nil assigns(:reason)
+  end
+
+  def test_it_should_create_reason_for_system_admin
+    params = { exclusion_reason: { reason: "Trod on false teeth" }}
+    assert_difference 'ExclusionReason.count' do
+      post regime_exclusion_reasons_path(@regime), params: params
+    end
+    assert_redirected_to regime_exclusion_reasons_path(@regime)
+  end
+
+  def test_it_should_get_edit_for_system_admin
+    get edit_regime_exclusion_reason_path(@regime, @reasons.first)
+    assert_response :success
+    assert_equal @reasons.first, assigns(:reason)
+  end
+
+  def test_it_should_update_reason_for_system_admin
+    params = { exclusion_reason: { reason: "Slightly shrimpy smell" }}
+    patch regime_exclusion_reason_path(@regime, @reasons.first), params: params
+    assert_equal "Slightly shrimpy smell", @reasons.first.reload.reason
+    assert_redirected_to regime_exclusion_reasons_path(@regime)
+  end
+
+  def test_it_should_delete_reason_for_system_admin
+    assert_difference 'ExclusionReason.count', -1 do
+      delete regime_exclusion_reason_path(@regime, @reasons.first)
+    end
+    assert_redirected_to regime_exclusion_reasons_path(@regime)
+  end
+
+  def test_it_should_get_index_for_billing_admin
+    sign_in users(:billing_admin)
+    get regime_exclusion_reasons_path(@regime)
+    assert_response :success
+    assert_equal @reasons, assigns(:reasons)
+  end
+
+  def test_it_should_not_get_new_for_billing_admin
+    sign_in users(:billing_admin)
+    get new_regime_exclusion_reason_path(@regime)
+    assert_redirected_to root_path
+  end
+
+  def test_it_should_not_create_for_billing_admin
+    sign_in users(:billing_admin)
+    params = { exclusion_reason: { reason: "Trod on false teeth" }}
+    assert_no_difference 'ExclusionReason.count' do
+      post regime_exclusion_reasons_path(@regime), params: params
+    end
+    assert_redirected_to root_path
+  end
+
+  def test_it_should_not_get_edit_for_billing_admin
+    sign_in users(:billing_admin)
+    get edit_regime_exclusion_reason_path(@regime, @reasons.first)
+    assert_redirected_to root_path
+  end
+
+  def test_it_should_not_update_reason_for_billing_admin
+    sign_in users(:billing_admin)
+    params = { exclusion_reason: { reason: "Slightly shrimpy smell" }}
+    patch regime_exclusion_reason_path(@regime, @reasons.first), params: params
+    assert_not_equal "Slightly shrimpy smell", @reasons.first.reload.reason
+    assert_redirected_to root_path
+  end
+
+  def test_it_should_not_delete_reason_for_billing_admin
+    sign_in users(:billing_admin)
+    assert_no_difference 'ExclusionReason.count' do
+      delete regime_exclusion_reason_path(@regime, @reasons.first)
+    end
+    assert_redirected_to root_path
+  end
+end

--- a/test/fixtures/exclusion_reasons.yml
+++ b/test/fixtures/exclusion_reasons.yml
@@ -1,0 +1,14 @@
+pas:
+  regime: pas
+  reason: "PAS reason"
+  active: true
+
+cfd:
+  regime: cfd
+  reason: "CFD reason"
+  active: true
+
+wml:
+  regime: wml
+  reason: "WML reason"
+  active: true

--- a/test/presenters/wml_transaction_detail_presenter_test.rb
+++ b/test/presenters/wml_transaction_detail_presenter_test.rb
@@ -37,6 +37,11 @@ class WmlTransactionDetailPresenterTest < ActiveSupport::TestCase
                  @presenter.compliance_band_with_percent)
   end
 
+  def test_it_returns_blank_if_compliance_band_100_percent
+    set_charge_calculation_compliance(@transaction, " (100%)")
+    assert @presenter.compliance_band_with_percent.blank?
+  end
+
   def test_credit_line_description_modifies_the_line_description
     @presenter.category = "2.15.2"
     val = "Credit of subsistence charge for permit category 2.15.2 due to the "\


### PR DESCRIPTION
Transactions with blank compliance band values should be left blank in the output transactions files for WML even though the rules engine returns ' (100%)' for the adjustment value.