### PR TITLE
Made transaction filename uppercase for Waste

### DIFF
--- a/app/models/transaction_file.rb
+++ b/app/models/transaction_file.rb
@@ -17,7 +17,11 @@ class TransactionFile < ApplicationRecord
   end
 
   def filename
-    @filename ||= "#{base_filename}.dat".downcase
+    unless @filename
+      @filename = "#{base_filename}.DAT"
+      @filename = @filename.downcase unless regime.waste?
+    end
+    @filename
   end
 
   def base_filename

--- a/test/controllers/history_controller_test.rb
+++ b/test/controllers/history_controller_test.rb
@@ -15,5 +15,9 @@ class HistoryControllerTest < ActionDispatch::IntegrationTest
     get regime_history_index_url(@regime, format: :json)
     assert_response :success
   end
-end
 
+  def test_it_should_get_index_for_csv
+    get regime_history_index_url(@regime, format: :csv)
+    assert_response :success
+  end
+end

--- a/test/models/transaction_file_test.rb
+++ b/test/models/transaction_file_test.rb
@@ -31,4 +31,38 @@ class TransactionFileTest < ActiveSupport::TestCase
     f = @retro_file
     assert_equal "#{@regime.to_param}#{f.region}I#{f.file_id}.dat".downcase, f.filename
   end
+
+  def test_filename_is_lowercase_for_Water_Quality
+    [@sroc_file, @retro_file].each do |f|
+      assert_equal f.filename.downcase, f.filename
+    end
+  end
+
+  def test_filename_is_lowercase_for_Installations
+    @regime = regimes(:pas)
+    @sroc_file = @regime.transaction_files.create(user: @user,
+                                                   region: 'A',
+                                                   retrospective: false)
+
+    @retro_file = @regime.transaction_files.create(user: @user,
+                                                   region: 'B',
+                                                   retrospective: true)
+    [@sroc_file, @retro_file].each do |f|
+      assert_equal f.filename.downcase, f.filename
+    end
+  end
+
+  def test_filename_is_uppercase_for_Waste
+    @regime = regimes(:wml)
+    @sroc_file = @regime.transaction_files.create(user: @user,
+                                                   region: 'A',
+                                                   retrospective: false)
+
+    @retro_file = @regime.transaction_files.create(user: @user,
+                                                   region: 'B',
+                                                   retrospective: true)
+    [@sroc_file, @retro_file].each do |f|
+      assert_equal f.filename.upcase, f.filename
+    end
+  end
 end


### PR DESCRIPTION
Transaction filenames for Waste need to be all uppercase.  Water Quality and Installations are all lowercase.