### PR TITLE
Fixed PAS filenames. Defect 124

### DIFF
--- a/app/models/transaction_file.rb
+++ b/app/models/transaction_file.rb
@@ -18,8 +18,10 @@ class TransactionFile < ApplicationRecord
 
   def filename
     unless @filename
-      @filename = "#{base_filename}.DAT"
-      @filename = @filename.downcase unless regime.waste?
+      base = base_filename
+      base.downcase! if regime.water_quality?
+      ext = regime.waste? ? '.DAT' : '.dat'
+      @filename = "#{base}#{ext}"
     end
     @filename
   end

--- a/test/models/transaction_file_test.rb
+++ b/test/models/transaction_file_test.rb
@@ -38,7 +38,7 @@ class TransactionFileTest < ActiveSupport::TestCase
     end
   end
 
-  def test_filename_is_lowercase_for_Installations
+  def test_filename_is_uppercase_for_Installations
     @regime = regimes(:pas)
     @sroc_file = @regime.transaction_files.create(user: @user,
                                                    region: 'A',
@@ -48,11 +48,14 @@ class TransactionFileTest < ActiveSupport::TestCase
                                                    region: 'B',
                                                    retrospective: true)
     [@sroc_file, @retro_file].each do |f|
-      assert_equal f.filename.downcase, f.filename
+      fn = f.filename
+      ext = File.extname(fn)
+      base = File.basename(fn, ext)
+      assert_equal "#{base.upcase}#{ext.downcase}", fn
     end
   end
 
-  def test_filename_is_uppercase_for_Waste
+  def test_filename_is_all_uppercase_for_Waste
     @regime = regimes(:wml)
     @sroc_file = @regime.transaction_files.create(user: @user,
                                                    region: 'A',


### PR DESCRIPTION
It transpires that PAS files must have uppercase filenames, despite having confirmation from the supplier that our previous (lowercase) files were fine. The filename extension can remain lowercase so as to avoid changing the ETL processes, so this fix just changes the base filename i.e. `pasei00002.dat` becomes `PASEI00002.dat`.  This fix is for SRoC and pre-SRoC retrospective filenames and only applies for the PAS regime.