### PR TITLE
Added validation around permit category code

### DIFF
--- a/app/models/permit_category.rb
+++ b/app/models/permit_category.rb
@@ -12,6 +12,9 @@ class PermitCategory < ApplicationRecord
   validate :valid_from_is_financial_year
   validate :valid_to_is_financial_year_or_nil
   validate :valid_from_and_valid_to_is_valid_range
+  validates :code, format: {
+    with: /\A(\d{1,4}|\d{1,4}.\d{1,4}|\d{1,4}.\d{1,4}.\d{1,4})\z/,
+    message: "^Code must be in dotted numeric format, with 1 to 3 segments  between 1 and 4 digits long. e.g. 6, 1.2, 9.34.1, 27.111.1234" }
   validates :code, presence: true, uniqueness: { scope: [:regime_id, :valid_from] }
   validates :description, presence: true, unless: :excluded?
   validates :description, length: { maximum: 150 }

--- a/app/views/permit_categories/_form.html.erb
+++ b/app/views/permit_categories/_form.html.erb
@@ -8,6 +8,12 @@
       <%= form.label :code %>
       <% if permit_category.new_record? %>
         <%= form.text_field :code, id: :permit_category_code, class: "form-control" %>
+      <div class="panel pt-2 mt-2 pb-2 mb-4 help-text">
+        Code must be in dotted number format. It may have between
+        1 and 3 segments seperated by a period (.). Each segment
+        may be between 1 and 4 digits in length.<br/>
+        For example: 27, 9.23, 54.1.1234, 12.34.56
+      </div>
       <% else %>
         <%= form.text_field :code, class: "form-control", readonly: true %>
       <% end %>

--- a/test/models/permit_category_test.rb
+++ b/test/models/permit_category_test.rb
@@ -15,6 +15,21 @@ class PermitCategoryTest < ActiveSupport::TestCase
     assert_not_nil @permit_category.errors[:code]
   end
 
+  def test_valid_when_code_formatted_correctly
+    %w[ 1 12.1111.2 1.9.9999 1.88 1234.1234.1234 ].each do |code|
+      @permit_category.code = code
+      assert @permit_category.valid?
+    end
+  end
+
+  def test_invalid_when_code_not_formatted_correctly
+    %w[ wigwam 12a 1.9.11111111 1.egg.88 ].each do |code|
+      @permit_category.code = code
+      assert @permit_category.invalid?
+      assert_not_nil @permit_category.errors[:code]
+    end
+  end
+
   def test_invalid_without_description_when_active
     @permit_category.status = 'active'
     @permit_category.description = nil


### PR DESCRIPTION
Fix for DEFECT 128

> There are no rules in place around what content, length or format a permit category code can have. 
> 
> When  code 1.9.11111111  was saved, for example, it broke the screen entirely ie non of the codes are displayed at all. I understand from Tony this is due to the way a SQL query sorts the set of permit codes. 
> 