### PR TITLE
Added in lookup for category_description for TTBB export

### DIFF
--- a/app/models/transaction_detail.rb
+++ b/app/models/transaction_detail.rb
@@ -78,6 +78,10 @@ class TransactionDetail < ApplicationRecord
   end
 
   def updateable?
+    unbilled?
+  end
+
+  def unbilled?
     status == 'unbilled'
   end
 

--- a/app/presenters/transaction_detail_presenter.rb
+++ b/app/presenters/transaction_detail_presenter.rb
@@ -70,6 +70,22 @@ class TransactionDetailPresenter < SimpleDelegator
           sprintf('%.2f', line_amount/100.0), unit: "")
   end
 
+  def category_description
+    desc = transaction_detail.category_description
+    return desc unless desc.blank?
+
+    # category description is not present until the user generates
+    # a transaction file. However, is should probably be included
+    # in a TTBB export if a category has been set even at the risk
+    # of the category description changing between assignment and 
+    # file generation
+    if transaction_detail.unbilled? && category.present?
+      pc = permit_store.code_for_financial_year(category, tcm_financial_year)
+      desc = pc.description unless pc.nil?
+    end
+    desc
+  end
+
   # def category_description
   #   if category.present?
   #     desc = PermitCategory.find_by(code: category).description
@@ -196,5 +212,9 @@ class TransactionDetailPresenter < SimpleDelegator
 protected
   def transaction_detail
     __getobj__
+  end
+
+  def permit_store
+    @permit_store ||= PermitStorageService.new(regime)
   end
 end

--- a/test/services/transaction_export_service_test.rb
+++ b/test/services/transaction_export_service_test.rb
@@ -1,0 +1,185 @@
+require 'test_helper.rb'
+
+class TransactionExportServiceTest < ActiveSupport::TestCase
+  include RegimePresenter, GenerateHistory
+
+  def setup
+    @regime = regimes(:cfd)
+    @exporter = TransactionExportService.new(@regime)
+    @permit_store = PermitStorageService.new(@regime)
+  end
+
+  def test_export_generates_csv_data
+    transactions = @regime.transaction_details.unbilled
+    assert transactions.count > 0, "No TTBB data"
+    data = @exporter.export(presenter.wrap(transactions))
+    idx = 0
+    CSV.parse(data, headers: true) do |row|
+      assert_equal @exporter.regime_columns, row.headers()
+      assert_equal row["Reference 1"], transactions[idx].reference_1
+      idx += 1
+    end
+  end
+
+  def test_export_looks_up_permit_category_description
+    transactions = @regime.transaction_details.unbilled
+    code = permit_categories(:cfd).code
+
+    assert transactions.count > 0, "No TTBB data"
+    transactions.update_all(category: code, category_description: nil)
+
+    data = @exporter.export(presenter.wrap(transactions))
+    idx = 0
+
+    CSV.parse(data, headers: true) do |row|
+      assert_equal @exporter.regime_columns, row.headers()
+      category = @permit_store.code_for_financial_year(code, row["Tcm Financial Year"])
+      if category
+        assert_equal category.description, row["Category Description"]
+      else
+        assert_nil row["Category Description"]
+      end
+      idx += 1
+    end
+  end
+
+  def test_export_history_generates_csv_data
+    generate_historic_cfd
+    transactions = @regime.transaction_details.historic
+    assert transactions.count > 0, "No historic test data"
+    data = @exporter.export_history(presenter.wrap(transactions))
+    idx = 0
+    CSV.parse(data, headers: true) do |row|
+      assert_equal @exporter.regime_history_columns, row.headers()
+      assert_equal row["Reference 1"], transactions[idx].reference_1
+      idx += 1
+    end
+  end
+
+  def test_regime_columns_returns_correct_columns
+    expected = [
+      "Customer Reference",
+      "Transaction Date",
+      "Transaction Type",
+      "Transaction Reference",
+      "Related Reference",
+      "Currency Code",
+      "Header Narrative",
+      "Header Attr 1",
+      "Header Attr 2",
+      "Header Attr 3",
+      "Header Attr 4",
+      "Header Attr 5",
+      "Header Attr 6",
+      "Header Attr 7",
+      "Header Attr 8",
+      "Header Attr 9",
+      "Header Attr 10",
+      "Currency Line Amount",
+      "Line Vat Code",
+      "Line Area Code",
+      "Line Description",
+      "Line Income Stream Code",
+      "Line Context Code",
+      "Line Attr 1",
+      "Line Attr 2",
+      "Line Attr 3",
+      "Line Attr 4",
+      "Line Attr 5",
+      "Line Attr 6",
+      "Line Attr 7",
+      "Line Attr 8",
+      "Line Attr 9",
+      "Line Attr 10",
+      "Line Attr 11",
+      "Line Attr 12",
+      "Line Attr 13",
+      "Line Attr 14",
+      "Line Attr 15",
+      "Line Quantity",
+      "Unit Of Measure",
+      "Currency Unit Of Measure Price",
+      "Reference 1",
+      "Reference 2",
+      "Reference 3",
+      "Variation",
+      "Temporary Cessation Flag",
+      "Category",
+      "Category Description",
+      "Period Start",
+      "Period End",
+      "Tcm Financial Year",
+      "Original Filename",
+      "Original File Date",
+      "Pro Rata Days",
+      "Currency Baseline Charge",
+      "Currency Tcm Charge"]
+    assert_equal expected, @exporter.regime_columns
+  end
+
+  def test_regime_history_columns_returns_correct_columns
+    expected = [
+      "Customer Reference",
+      "Transaction Date",
+      "Transaction Type",
+      "Transaction Reference",
+      "Related Reference",
+      "Currency Code",
+      "Header Narrative",
+      "Header Attr 1",
+      "Header Attr 2",
+      "Header Attr 3",
+      "Header Attr 4",
+      "Header Attr 5",
+      "Header Attr 6",
+      "Header Attr 7",
+      "Header Attr 8",
+      "Header Attr 9",
+      "Header Attr 10",
+      "Currency Line Amount",
+      "Line Vat Code",
+      "Line Area Code",
+      "Line Description",
+      "Line Income Stream Code",
+      "Line Context Code",
+      "Line Attr 1",
+      "Line Attr 2",
+      "Line Attr 3",
+      "Line Attr 4",
+      "Line Attr 5",
+      "Line Attr 6",
+      "Line Attr 7",
+      "Line Attr 8",
+      "Line Attr 9",
+      "Line Attr 10",
+      "Line Attr 11",
+      "Line Attr 12",
+      "Line Attr 13",
+      "Line Attr 14",
+      "Line Attr 15",
+      "Line Quantity",
+      "Unit Of Measure",
+      "Currency Unit Of Measure Price",
+      "Reference 1",
+      "Reference 2",
+      "Reference 3",
+      "Variation",
+      "Temporary Cessation Flag",
+      "Category",
+      "Category Description",
+      "Period Start",
+      "Period End",
+      "Tcm Financial Year",
+      "Original Filename",
+      "Original File Date",
+      "Pro Rata Days",
+      "Currency Baseline Charge",
+      "Currency Tcm Charge",
+      "Generated Filename",
+      "Tcm File Date",
+      "Tcm Transaction Type",
+      "Tcm Transaction Reference"]
+    assert_equal expected, @exporter.regime_history_columns
+  end
+end
+

--- a/test/support/generate_history.rb
+++ b/test/support/generate_history.rb
@@ -1,0 +1,31 @@
+module GenerateHistory
+  def generate_historic_cfd
+    f = transaction_files(:cfd_sroc_file)
+    t = transaction_details(:cfd)
+    history = []
+    tt = t.dup
+    tt.reference_1 = 'AAAA/1/1'
+    tt.reference_2 = '1' 
+    tt.reference_3 = '1'
+    tt.customer_reference = 'A1234'
+    tt.status = 'billed'
+    tt.line_amount = 12567
+    tt.category = '2.3.4'
+    tt.period_start = '1-APR-18'
+    tt.period_end = '31-MAR-19'
+    tt.tcm_financial_year = '1819'
+    tt.transaction_file_id = f.id
+    tt.save!
+    history << tt
+    ttt = tt.dup
+    ttt.line_amount = 32411
+    ttt.category = '2.3.5'
+    ttt.period_start = '1-APR-19'
+    ttt.period_end = '31-MAR-20'
+    ttt.tcm_financial_year = '1920'
+    tt.transaction_file_id = f.id
+    ttt.save!
+    history << ttt
+    history
+  end
+end


### PR DESCRIPTION
Permit category was missing in the CSV exports on TTBB.  This is because we do not populate the `:category_description` field until the `TransactionFile` is generated, at which point the transaction wouldn't be on TTBB.  So to remedy this we look up the category description during the export, but do not store it on the transaction at this point.  There is a risk that the description could be updated between exporting transactions and generating a transaction file in the future, but the Product Owner was happy this was a low risk and outweighed by the usefulness of having the description in the export.