### PR TITLE
Fix assigning charge after auto category assignment

### DIFF
--- a/app/services/permit_category_processor.rb
+++ b/app/services/permit_category_processor.rb
@@ -13,6 +13,10 @@ class PermitCategoryProcessor
   end
 
   def suggest_categories
+    send "process_#{regime.slug}_transactions"
+  end
+
+  def process_cfd_transactions
     consents = fetch_unique_consents
 
     consents.each do |consent|
@@ -49,8 +53,10 @@ class PermitCategoryProcessor
       transaction.charge_calculation = calc_charge(transaction)
       if transaction.charge_calculation_error?
         transaction.category = nil
+        transaction.tcm_charge = nil
         transaction.category_logic = 'Error assigning charge'
       else
+        transaction.tcm_charge = TransactionCharge.extract_correct_charge(transaction)
         transaction.category_logic = 'Assigned matching category'
       end
     end

--- a/test/services/permit_category_processor_test.rb
+++ b/test/services/permit_category_processor_test.rb
@@ -48,6 +48,14 @@ class PermitCategoryProcessorTest < ActiveSupport::TestCase
     assert_equal 'Assigned matching category', transaction.category_logic
   end
 
+  def test_set_category_sets_charge_info
+    transaction = @header.transaction_details.
+      find_by(reference_1: 'AAAA/1/1')
+    @processor.set_category(transaction, '2.3.4')
+    assert_not_nil transaction.charge_calculation
+    assert_not_nil transaction.tcm_charge
+  end
+
   def test_set_category_does_not_set_category_when_category_removed
     transaction = @header.transaction_details.
       find_by(reference_1: 'AAAA/1/1')


### PR DESCRIPTION
During auto category assignment (future years billings), after charge was returned from rules service, the actual charge amount wasn't being extracted into the `:tcm_charge` field.