### PR TITLE
Fixed issue when no matched_transaction

### DIFF
--- a/app/views/transactions/_suggested_category.html.erb
+++ b/app/views/transactions/_suggested_category.html.erb
@@ -17,7 +17,9 @@
         <dd><%= sc.overridden ? 'Yes' : 'No' %></dd>
       </dl>
     </div>
-    <%= render partial: 'matched_transaction',
-      locals: { transaction: present_transaction(sc.matched_transaction) } %></dd>
+    <% if sc.matched_transaction %>
+      <%= render partial: 'matched_transaction',
+        locals: { transaction: present_transaction(sc.matched_transaction) } %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
When suggested category process cannot find a match, there is no `:matched_transaction` and we need to prevent trying to access it in the view. This fixes the problem.