### PR TITLE
Added exclude and reinstate functionality to details view

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -16,6 +16,11 @@ function init() {
     init_new_permit_category_button(container)
     init_row(container)
   }
+
+  container = $('.exclusion-zone')
+  if (container.length > 0) {
+    init_exclusion_zone(container)
+  }
 }
 
 function init_row(container) {
@@ -252,6 +257,18 @@ function init_temporary_cessation_select (container) {
     row.find("td:nth-last-child(2)").html("Working ...")
     update_row(row, table, { temporary_cessation: $(this).val() })
   })
+}
+
+function init_exclusion_zone (container) {
+  console.log("init exclusion zone")
+  var dlg = container.find('.exclusion-dialog')
+  if (dlg.length > 0 ) {
+    container.find(".exclude-button").on('click', function (ev) {
+      ev.preventDefault()
+      console.log('exclude transactions')
+      dlg.modal()
+    })
+  }
 }
 
 function update_row(row, table, data) {

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -79,6 +79,7 @@ class TransactionsController < ApplicationController
   # GET /regimes/:regime_id/transactions/1.json
   def show
     @related_transactions = transaction_store.transactions_related_to(@transaction)
+    @exclusion_reasons = Query::Exclusions.call(regime: @regime)
   end
 
   # GET /regimes/:regimes_id/transactions/1/edit
@@ -101,7 +102,7 @@ class TransactionsController < ApplicationController
             render partial: "#{@regime.to_param}_transaction",
               locals: { transaction: presenter.new(@transaction, current_user) }
           else
-            redirect_to edit_regime_transaction_path(@regime, @transaction),
+            redirect_to regime_transaction_path(@regime, @transaction),
               notice: 'Transaction was successfully updated.'
           end
         end
@@ -118,7 +119,7 @@ class TransactionsController < ApplicationController
             render partial: "#{@regime.to_param}_transaction",
               locals: { transaction: presenter.new(@transaction, current_user) }
           else
-            redirect_to edit_regime_transaction_path(@regime, @transaction),
+            redirect_to regime_transaction_path(@regime, @transaction),
               notice: 'Transaction was not updated.'
           end
         end

--- a/app/services/query/exclusions.rb
+++ b/app/services/query/exclusions.rb
@@ -1,0 +1,13 @@
+module Query
+  class Exclusions < QueryObject
+    def initialize(opts = {})
+      @regime = opts.fetch(:regime)
+    end
+
+    def call
+      # NOTE: doesn't return a query
+      @regime.exclusion_reasons.order(:reason).pluck(:reason)
+    end
+  end
+end
+

--- a/app/services/update_transaction.rb
+++ b/app/services/update_transaction.rb
@@ -27,7 +27,7 @@ class UpdateTransaction < ServiceObject
       if str_to_bool(attrs.fetch(:excluded))
         ExcludeTransaction.call(transaction: transaction, user: user)
       else
-        UnexludeTransaction.call(transaction: transaction, user: user)
+        UnexcludeTransaction.call(transaction: transaction, user: user)
       end
     elsif attrs.has_key?(:approved_for_billing)
       if str_to_bool(attrs.fetch(:approved_for_billing))

--- a/app/views/shared/_summary_dialog.html.erb
+++ b/app/views/shared/_summary_dialog.html.erb
@@ -1,4 +1,4 @@
-<div id="summary-dialog" class='modal fade' tabIndex='-1' role='dialog'
+<div id="summary-dialog" class='modal fade' role='dialog'
      data-backdrop='static' aria-hidden='true'>
   <div class='modal-dialog' role='document'>
     <div class='modal-content'>

--- a/app/views/transactions/_detail_summary.html.erb
+++ b/app/views/transactions/_detail_summary.html.erb
@@ -55,6 +55,9 @@
           <span class="<%= "badge badge-pill badge-#{status_colour(transaction.status)}" %>">
             <%= status_text(transaction.status) -%>
           </span>
+          <% if transaction.unbilled? && transaction.excluded? %>
+            <span class="badge badge-pill badge-danger">Marked for Exclusion</span>
+          <% end %>
         </dd>
       </dl>
     </div>

--- a/app/views/transactions/_exclusion_dialog.html.erb
+++ b/app/views/transactions/_exclusion_dialog.html.erb
@@ -1,0 +1,48 @@
+<div class="modal fade exclusion-dialog" role="dialog"
+  data-backdrop="static" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Exclude Transaction</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="row">
+          <div class="col">
+            <h6 class="heading-small" id="reason-label">
+              Select the reason for excluding this transaction
+            </h6>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <div class="panel">
+              <select class="form-control" name="reason-selector" id="reason-selector" aria-labelledby="reason-label">
+                <%= reasons.each do |reason| %>
+                  <option value="<%= reason %>"><%= reason %></option>
+                <% end %>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <%= form_with(url: regime_transaction_path(@regime, transaction),
+                      method: :patch,
+                      local: true) do |f| %>
+        <input type="hidden"
+               name="transaction_detail[excluded]"
+               value="true" />
+
+        <% if reasons.length.positive? %>
+          <%= f.submit 'Exclude Transaction', class: 'btn btn-danger' %>
+        <% end %>
+          <button type="button" class="btn btn-secondary"
+                  id="cancel-button" data-dismiss="modal">Cancel</button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -5,6 +5,24 @@
 </div>
 <% transaction = present_transaction(@transaction) %>
 <%= render partial: "detail_summary", locals: { transaction: transaction } %>
+<% if transaction.unbilled? %>
+  <div class="exclusion-zone">
+    <% if transaction.excluded? %>
+        <%= form_with(url: regime_transaction_path(@regime, transaction),
+                      method: :patch,
+                      local: true) do |f| %>
+        <input type="hidden"
+               name="transaction_detail[excluded]"
+               value="false" />
+        <%= f.submit 'Reinstate for Billing', class: 'btn btn-success' %>
+        <% end %>
+    <% else %>
+      <button class="btn btn-danger exclude-button">Exclude from Billing</button>
+      <%= render partial: 'exclusion_dialog', locals: { transaction: transaction,
+                                                        reasons: @exclusion_reasons } %>
+    <% end %>
+  </div>
+<% end %>
 <hr />
 <% unless transaction.retrospective? %>
   <div class="row">


### PR DESCRIPTION
Added functionality for excluding and reinstating transactions into the transaction details view. This was previously a check box on the transactions list but was moved here so we could use the per-row checkbox for the transaction checking/approval functionality.