### PR TITLE
Managing region selector explicitly in controllers

### DIFF
--- a/app/controllers/concerns/query_transactions.rb
+++ b/app/controllers/concerns/query_transactions.rb
@@ -2,16 +2,16 @@ module QueryTransactions
   extend ActiveSupport::Concern
 
   def query_params
-    region = params.fetch(:region, cookies.fetch(:region, ''))
-    region = '' if region == 'all'
+    # region = params.fetch(:region, cookies.fetch(:region, ''))
+    # region = '' if region == 'all'
     {
       regime: @regime,
+      region: @region,
+      financial_year: @financial_year,
       search: params.fetch(:search, cookies.fetch(:search, '')),
-      region: region,
       sort: params.fetch(:sort, cookies.fetch(:sort, 'customer_reference')),
       sort_direction: params.fetch(:sort_direction,
-                                   cookies.fetch(:sort_direction, 'asc')),
-      financial_year: @financial_year
+                                   cookies.fetch(:sort_direction, 'asc'))
     }
   end
 end

--- a/app/controllers/exclusions_controller.rb
+++ b/app/controllers/exclusions_controller.rb
@@ -9,14 +9,9 @@ class ExclusionsController < ApplicationController
   # GET /regimes/:regime_id/exclusions
   # GET /regimes/:regime_id/exclusions.json
   def index
-    # regions = transaction_store.exclusion_regions
-    # @region = params.fetch(:region, '')
-    # @region = regions.first unless @region.blank? || regions.include?(@region)
-    # q = params.fetch(:search, "")
-    # sort_col = params.fetch(:sort, :customer_reference)
-    # sort_dir = params.fetch(:sort_direction, 'asc')
-    # fy = params.fetch(:fy, '')
     @region = params.fetch(:region, cookies.fetch(:region, ''))
+    @region = '' if @region == 'all'
+
     pg = params.fetch(:page, cookies.fetch(:page, 1))
     per_pg = params.fetch(:per_page, cookies.fetch(:per_page, 10))
 

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -10,6 +10,7 @@ class HistoryController < ApplicationController
   # GET /regimes/:regime_id/history.json
   def index
     @region = params.fetch(:region, cookies.fetch(:region, ''))
+    @region = '' if @region == 'all'
 
     pg = params.fetch(:page, cookies.fetch(:page, 1))
     per_pg = params.fetch(:per_page, cookies.fetch(:per_page, 10))

--- a/app/controllers/retrospectives_controller.rb
+++ b/app/controllers/retrospectives_controller.rb
@@ -10,6 +10,8 @@ class RetrospectivesController < ApplicationController
   # GET /regimes/:regime_id/history.json
   def index
     @region = params.fetch(:region, cookies.fetch(:region, ''))
+    @region = '' if @region == 'all'
+
     pg = params.fetch(:page, 1)
     per_pg = params.fetch(:per_page, 10)
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -4,70 +4,34 @@ class TransactionsController < ApplicationController
   include RegimeScope, FinancialYear, CsvExporter, QueryTransactions
   before_action :set_regime, only: [:index, :approve]
   before_action :set_transaction, only: [:show, :edit, :update]
-  before_action :set_current_user, only: [:update, :approve]
+  # before_action :set_current_user, only: [:update, :approve]
 
   # GET /regimes/:regime_id/transactions
   # GET /regimes/:regime_id/transactions.json
   def index
-    # regions = transaction_store.unbilled_regions
-    # mode = params.fetch(:view_mode, 'unbilled')
-    # if mode == 'unbilled'
-      # @region = params.fetch(:region, cookies[:region])
-      # @region = regions.first if @region.blank? #unless regions.include? @region
-    # else
     regions = Query::Regions.call(regime: @regime)
     @region = params.fetch(:region, cookies.fetch(:region, ''))
     @region = regions.first if @region.blank? || @region == 'all'
 
-    # end
-
-    # q = params.fetch(:search, cookies[:search] || '')
-    # sort_col = params.fetch(:sort, cookies[:sort] || '')
-    # sort_dir = params.fetch(:sort_direction, cookies[:sort_direction] || 'asc')
-      pg = params.fetch(:page, cookies.fetch(:page, 1))
-      per_pg = params.fetch(:per_page, cookies.fetch(:per_page, 10))
+    pg = params.fetch(:page, cookies.fetch(:page, 1))
+    per_pg = params.fetch(:per_page, cookies.fetch(:per_page, 10))
 
     @financial_years = Query::FinancialYears.call(regime: @regime)
     @financial_year = params.fetch(:fy, cookies.fetch(:fy, ''))
     @financial_year = '' unless @financial_years.include? @financial_year
 
     @transactions = Query::TransactionsToBeBilled.call(query_params)
-    # regime: @regime,
-    #                                                  region: @region,
-    #                                                  sort_column: sort_col,
-    #                                                  sort_direction: sort_dir,
-    #                                                  search: q)
-
-    # @transactions = transaction_store.transactions_to_be_billed(
-    #   q,
-    #   pg,
-    #   per_pg,
-    #   @region,
-    #   sort_col,
-    #   sort_dir
-    # )
-
-    # don't want to display these here for now
-    # summary = transaction_store.transactions_to_be_billed_summary(q, region)
     summary = nil
 
     respond_to do |format|
       format.html do
         @transactions = present_transactions(@transactions.page(pg).per(per_pg))
-        # @categories = current_permit_categories 
         if request.xhr?
           render partial: "table", locals: { transactions: @transactions }
         else
           render
         end
       end
-      # format.json do
-      #   @transactions = present_transactions_for_json(@transactions.page(pg).per(per_pg),
-      #                                                 @region,
-      #                                                 regions,
-      #                                                 summary)
-      #   render json: @transactions
-      # end
       format.csv do
         send_data csv.export(presenter.wrap(@transactions.unexcluded.limit(15000))),
           csv_opts
@@ -78,7 +42,8 @@ class TransactionsController < ApplicationController
   # GET /regimes/:regime_id/transactions/1
   # GET /regimes/:regime_id/transactions/1.json
   def show
-    @related_transactions = transaction_store.transactions_related_to(@transaction)
+    # @related_transactions = transaction_store.transactions_related_to(@transaction)
+    @related_transactions = Query::RelatedTransactions.call(transaction: @transaction)
     @exclusion_reasons = Query::Exclusions.call(regime: @regime)
   end
 
@@ -166,97 +131,6 @@ class TransactionsController < ApplicationController
   end
 
   private
-    def current_permit_categories
-      permit_store.active_list_for_selection(current_financial_year).
-        pluck(:code).map do |c|
-          { value: c, label: c }
-        end
-    end
-
-    def update_transaction
-      if @transaction.updateable?
-        if @transaction.update(transaction_params)
-        # @transaction.assign_attributes(transaction_params)
-        # if @transaction.valid?
-          # category_changes = @transaction.changes[:category]
-          # tc_changes = @transaction.changes[:temporary_cessation]
-          category_changes = @transaction.previous_changes[:category]
-          tc_changes = @transaction.previous_changes[:temporary_cessation]
-          exclusion_changes = @transaction.previous_changes[:excluded]
-
-          if tc_changes 
-            if @transaction.category.present?
-              @transaction.charge_calculation = get_charge_calculation
-              if @transaction.charge_calculation_error?
-                @transaction.temporary_cessation = tc_changes[0]
-                @transaction.tcm_charge = nil
-              else
-                @transaction.tcm_charge = TransactionCharge.extract_correct_charge(@transaction)
-              end
-            else
-              # we might have an error from a previous interaction so remove it
-              @transaction.charge_calculation = nil
-            end
-            @transaction.save
-            # if @transaction.save
-            #   auditor.log_modify(@transaction)
-            #   true
-            # else
-            #   false
-            # end
-          elsif category_changes
-            # always get charge when category changes unless blank
-            @transaction.charge_calculation = get_charge_calculation
-            # restore category if charge calc error
-            if @transaction.charge_calculation_error?
-              @transaction.category = category_changes[0]
-              @transaction.tcm_charge = nil
-            else
-              # extract charge calculation and correctly sign it
-              @transaction.tcm_charge = TransactionCharge.extract_correct_charge(@transaction)
-              if @transaction.suggested_category
-                @transaction.suggested_category.update_attributes(overridden: true)
-              end
-            end
-            # auditor.log_modify(@transaction)
-            @transaction.save
-            # if @transaction.save
-            #   auditor.log_modify(@transaction)
-            #   true
-            # else
-            #   false
-            # end
-          elsif exclusion_changes
-            if exclusion_changes[0] == true
-              # was excluded now reinstate
-              @transaction.charge_calculation = get_charge_calculation
-              unless @transaction.charge_calculation_error?
-                @transaction.tcm_charge = TransactionCharge.extract_correct_charge(@transaction)
-              end
-            else
-              # become excluded
-              @transaction.charge_calculation = nil
-              @transaction.tcm_charge = nil
-            end
-            @transaction.save
-          else
-            # nothing changing but don't want to generate an error
-            true
-          end
-        else
-          false
-        end
-      else
-        @transaction.errors.add(:category, "Transaction cannot be updated")
-        false
-      end
-    end
-
-    def get_charge_calculation
-      TransactionCharge.invoke_charge_calculation(calculator,
-                                                  presenter.new(@transaction)) if @transaction.category.present?
-    end
-
     def present_transactions(transactions)
       Kaminari.paginate_array(presenter.wrap(transactions, current_user),
                               total_count: transactions.total_count,
@@ -264,59 +138,15 @@ class TransactionsController < ApplicationController
                               offset: transactions.offset_value)
     end
 
-    def present_transactions_for_json(transactions, selected_region, regions, summary)
-      arr = present_transactions(transactions)
-      # arr = Kaminari.paginate_array(presenter.wrap(transactions, current_user),
-      #                               total_count: transactions.total_count,
-      #                               limit: transactions.limit_value,
-      #                               offset: transactions.offset_value)
-      {
-        pagination: {
-          current_page: arr.current_page,
-          prev_page: arr.prev_page,
-          next_page: arr.next_page,
-          per_page: arr.limit_value,
-          total_pages: arr.total_pages,
-          total_count: arr.total_count
-        },
-        transactions: arr,
-        selected_region: selected_region,
-        regions: region_options(regions)
-      }
-    end
-
-    def region_options(regions)
-      regions.map { |r| { label: r, value: r } }
-    end
-
     def set_transaction
       set_regime
-      @transaction = transaction_store.find(params[:id])
+      @transaction = Query::FindTransaction.call(regime: @regime,
+                                                 transaction_id: params[:id])
     end
 
     def transaction_params
       params.require(:transaction_detail).permit(:category, :temporary_cessation,
                                                  :excluded, :excluded_reason,
                                                  :approved_for_billing)
-    end
-
-    def transaction_store
-      @transaction_store ||= TransactionStorageService.new(@regime, current_user)
-    end
-
-    def calculator
-      @calculator ||= CalculationService.new
-    end
-
-    def auditor
-      @auditor ||= AuditService.new(current_user)
-    end
-
-    def permit_store
-      @permit_store ||= PermitStorageService.new(@regime, current_user)
-    end
-
-    def set_current_user
-      Thread.current[:current_user] = current_user
     end
 end

--- a/app/services/query/find_transaction.rb
+++ b/app/services/query/find_transaction.rb
@@ -1,0 +1,13 @@
+module Query
+  class FindTransaction < QueryObject
+    def initialize(opts = {})
+      @regime = opts.fetch(:regime)
+      @transaction_id = opts.fetch(:transaction_id)
+    end
+
+    def call
+      # NOTE: doesn't return a query
+      @regime.transaction_details.find(@transaction_id)
+    end
+  end
+end

--- a/app/services/query/related_transactions.rb
+++ b/app/services/query/related_transactions.rb
@@ -1,0 +1,29 @@
+module Query
+  class RelatedTransactions < QueryObject
+    def initialize(opts = {})
+      @transaction = opts.fetch(:transaction)
+    end
+
+    def call
+      regime = @transaction.regime
+      at = TransactionDetail.arel_table
+      q = regime.transaction_details.unbilled.where.not(id: @transaction.id)
+      if regime.installations?
+        q = q.where.not(reference_3: nil).
+          where.not(reference_3: 'NA').
+          where(reference_3: @transaction.reference_3).
+          or(q.where.not(reference_1: 'NA').
+             where.not(reference_1: nil).
+             where(reference_1: @transaction.reference_1)).
+          or(q.where.not(reference_2: 'NA').
+             where.not(reference_2: nil).
+             where(reference_2: @transaction.reference_2))
+      else
+        q = q.where.not(reference_1: nil).
+          where.not(reference_1: 'NA').
+          where(reference_1: @transaction.reference_1)
+      end
+      q.order(:reference_1)
+    end
+  end
+end


### PR DESCRIPTION
Region could get 'lost' between requests especially across controllers. Each one now extracts `@region` from `params` and handles how it wants to handle 'all' or '' values. 