### PR TITLE
Show amount as formatted pounds and pence for retrospectives

### DIFF
--- a/app/views/retrospectives/_cfd_transaction.html.erb
+++ b/app/views/retrospectives/_cfd_transaction.html.erb
@@ -31,6 +31,6 @@
     <%= transaction.period %>
   </td>
   <td class="align-middle text-right">
-    <%= transaction.line_amount %>
+    <%= transaction.currency_line_amount %>
   </td>
 </tr>

--- a/app/views/retrospectives/_pas_transaction.html.erb
+++ b/app/views/retrospectives/_pas_transaction.html.erb
@@ -28,6 +28,6 @@
     <%= transaction.period %>
   </td>
   <td class="align-middle text-right">
-    <%= transaction.line_amount %>
+    <%= transaction.currency_line_amount %>
   </td>
 </tr>

--- a/app/views/retrospectives/_wml_transaction.html.erb
+++ b/app/views/retrospectives/_wml_transaction.html.erb
@@ -25,6 +25,6 @@
     <%= transaction.period %>
   </td>
   <td class="align-middle text-right">
-    <%= transaction.amount %>
+    <%= transaction.currency_line_amount %>
   </td>
 </tr>


### PR DESCRIPTION
Use correct presenter method to display pounds and pence rather than unformatted pence. This only affected retrospective transactions.