### PR TITLE
Reintroduced admin lock check for category

### DIFF
--- a/app/views/transactions/_cfd_transaction.html.erb
+++ b/app/views/transactions/_cfd_transaction.html.erb
@@ -27,7 +27,7 @@
     <%= transaction.discharge_reference %>
   </td>
   <td class="align-middle control-column">
-    <% if transaction.editable? %>
+    <% if transaction.can_update_category? && transaction.editable? %>
       <%= category_select_tag transaction %>
     <% else %>
       <%= transaction.category %>

--- a/app/views/transactions/_pas_transaction.html.erb
+++ b/app/views/transactions/_pas_transaction.html.erb
@@ -24,7 +24,7 @@
     <%= transaction.original_permit_reference %>
   </td>
   <td class="align-middle control-column">
-    <% if transaction.editable? %>
+    <% if transaction.can_update_category? && transaction.editable? %>
       <%= category_select_tag transaction %>
     <% else %>
       <%= transaction.category %>

--- a/app/views/transactions/_wml_transaction.html.erb
+++ b/app/views/transactions/_wml_transaction.html.erb
@@ -21,7 +21,7 @@
     <%= transaction.permit_reference %>
   </td>
   <td class="align-middle control-column">
-    <% if transaction.editable? %>
+    <% if transaction.can_update_category? && transaction.editable? %>
       <%= category_select_tag transaction %>
     <% else %>
       <%= transaction.category %>


### PR DESCRIPTION
Added checks for user `role` and `suggested_category.admin_lock` on transaction category to prevent changes to category when credit transaction has a suggested category and user is a billing admin.