### PR TITLE
Verified that history search fixed by defect_190 fix

### DIFF
--- a/test/services/query/billed_transactions_test.rb
+++ b/test/services/query/billed_transactions_test.rb
@@ -7,7 +7,7 @@ module Query
     def setup
       @regime = regimes(:cfd)
       @user = users(:billing_admin)
-      generate_historic_cfd
+      @history = generate_historic_cfd
     end
 
     def test_returns_historic_transactions
@@ -20,6 +20,19 @@ module Query
 
       transactions.each do |t|
         assert_includes q, t, "Where did #{t.reference_1} come from?"
+      end
+    end
+
+    def test_it_can_search_extra_attributes
+      @history.each do |t|
+        t.update_attributes(tcm_transaction_reference: "x1y2z3",
+                            generated_filename: "wig77wam")
+      end
+      # search category, tcm_transaction_reference, generated_filename
+      [ '3.4', 'y2z', 'wig77' ].each do |v|
+        transactions = BilledTransactions.call(regime: @regime,
+                                               search: v)
+        assert transactions.count.positive?, "Failed on [#{v}]"
       end
     end
   end


### PR DESCRIPTION
Fix for defect 190 also fixes issue where extra searchable fields are not being used. This was caused by the wrong search method being called that only considered the TTBB criteria not the extra fields present for billed transactions.