### PR TITLE
Fixed category select scrollbar issue

### DIFF
--- a/app/assets/javascripts/tcm_select.js
+++ b/app/assets/javascripts/tcm_select.js
@@ -23,7 +23,12 @@
       })
 
       input.on('blur', function (ev) {
-        handleBlur(ev, elements)
+        if (elements.mouseDown) {
+          elements.mouseDown = false
+          ev.target.focus()
+        } else {
+          handleBlur(ev, elements)
+        }
       })
 
       input.on('click', function (ev) {
@@ -277,6 +282,15 @@
     elements.list = list
     elements.wrapper.find(".tcm-select-list-wrapper").remove()
     elements.wrapper.append(list)
+
+    // this prevents clicks on the scrollbar from triggering a blur that closes the list
+    elements.wrapper.find(".tcm-select-list").on('mousedown', function (ev) {
+      elements.mouseDown = true
+      setTimeout(function () {
+        elements.mouseDown = false
+      }, 0)
+    })
+
     var coll = $(".tcm-select-list-item")
     coll.hover(
       function () {


### PR DESCRIPTION
Clicking on the scrollbar when the category select control was open was causing it to shut.  This was because it was triggering a blur event. This was occurring (differently) in both Chrome and IE11.