### PR TITLE
Restored search clear button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,5 @@
 @import "annual_billing";
 @import "auth";
 @import "errors";
+// keep ui-fixes last
+@import "ui-fixes";

--- a/app/assets/stylesheets/ui-fixes.scss
+++ b/app/assets/stylesheets/ui-fixes.scss
@@ -1,0 +1,15 @@
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: searchfield-cancel-button;
+}
+
+input[type="search"]::-ms-clear {
+  display: inline-block;
+  width: initial;
+  height: initial;
+}
+
+input[type="search"]::-ms-reveal {
+  display: block;
+  width: initial;
+  height: initial;
+}


### PR DESCRIPTION
Restored search box `input[type=search]` clear button for webkit and IE. Presumably removed by bootstrap or some other css.