### PR TITLE
Made popover close on loss of focus

### DIFF
--- a/app/views/transactions/_cfd_transaction.html.erb
+++ b/app/views/transactions/_cfd_transaction.html.erb
@@ -59,10 +59,11 @@
   <% if transaction.charge_calculation_error? %>
     <td class="align-middle error-popup">
       <button type="button"
+              id="<%= transaction.id %>-error"
               class="btn btn-sm"
               title="Error"
-              data-container="body"
               data-toggle="popover"
+              data-trigger="focus"
               data-placement="left"
               data-content="<%= transaction.error_message %>">
         <span class="oi oi-warning" aria-hidden="true"></span>

--- a/app/views/transactions/_pas_transaction.html.erb
+++ b/app/views/transactions/_pas_transaction.html.erb
@@ -55,9 +55,10 @@
   <% if transaction.charge_calculation_error? %>
     <td class="align-middle error-popup">
       <button type="button"
+              id="<%= transaction.id %>-error"
               class="btn btn-sm"
               title="Error"
-              data-container="body"
+              data-trigger="focus"
               data-toggle="popover"
               data-placement="left"
               data-content="<%= transaction.error_message %>">

--- a/app/views/transactions/_wml_transaction.html.erb
+++ b/app/views/transactions/_wml_transaction.html.erb
@@ -52,9 +52,10 @@
   <% if transaction.charge_calculation_error? %>
     <td class="align-middle error-popup">
       <button type="button"
+              id="<%= transaction.id %>-error"
               class="btn btn-sm"
               title="Error"
-              data-container="body"
+              data-trigger="focus"
               data-toggle="popover"
               data-placement="left"
               data-content="<%= transaction.error_message %>">

--- a/test/fixtures/transaction_details.yml
+++ b/test/fixtures/transaction_details.yml
@@ -140,6 +140,32 @@ cfd_unbilled_credit_2:
   tcm_financial_year: "1718"
 
 
+cfd_unbilled_error_invoice:
+  <<: *DEFAULTS
+  customer_reference: "Z344522"
+  transaction_reference: <%= rand(36**8).to_s(36).upcase %>
+  transaction_date: <%= 2.months.ago %>
+  header_attr_1: <%= 2.months.ago.strftime("%d-%^b-%Y") %>
+  line_amount: 23747
+  line_description: "Consent No - ERROR/1234/1/1"
+  line_attr_1: "Polka Rd. Hamster Disposal"
+  line_attr_2: "STORM CORNFLAKE OVERFLOW"
+  line_attr_3: "01/04/17 - 10/08/17"
+  line_attr_9: "96%"
+  unit_of_measure_price: 23747
+  status: "unbilled"
+  reference_1: "ERROR/1234/1/1"
+  reference_2: "1"
+  reference_3: "1"
+  period_start: "01-Apr-2017"
+  period_end: "10-Aug-2017"
+  original_filename: 'CFDBI00123'
+  original_file_date: <%= 2.weeks.ago.to_date %>
+  tcm_financial_year: "1718"
+  charge_calculation:
+    calculation:
+      messages: "Error message"
+
 ###########################################################
 # CFD - Historic billed transactions
 #

--- a/test/integration/error_popup_test.rb
+++ b/test/integration/error_popup_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class ErrorPopupTest < ActionDispatch::IntegrationTest
+  def setup
+    Capybara.current_driver = Capybara.javascript_driver
+    @regime = regimes(:cfd)
+    @user = users(:billing_admin)
+    @regions_only = @regime.transaction_headers.distinct.pluck(:region).sort
+    @regions_with_all = [ 'All' ] + @regions_only
+    @error_transaction = transaction_details(:cfd_unbilled_error_invoice)
+    sign_in @user
+  end
+
+  def test_can_see_error_row_on_ttbb
+    visit regime_transactions_path(@regime)
+
+    page.assert_selector("tr.error", count: 1)
+  end
+
+  def test_can_see_error_message_when_clicked_on_ttbb
+    visit regime_transactions_path(@regime)
+    id = "#{@error_transaction.id}-error"
+    msg = @error_transaction.charge_calculation['calculation']['messages']
+
+    # click error details button
+    page.click_button(id: id)
+    # look at popover that appears
+    page.find(".popover", visible: true) do |pop|
+      pop.find(".popover-header").assert_text("Error")
+      pop.find(".popover-body").assert_text(msg)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,7 +34,8 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 # Capybara.javascript_driver = :chrome
-Capybara.javascript_driver = :headless_chrome
+driver = ENV.fetch('TEST_DRIVER', :headless_chrome)
+Capybara.javascript_driver = driver.to_sym
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
Fixed issue with popover staying on screen by making it close when `focus` is triggered.