### PR TITLE
Removed retrospective view access for Waste

### DIFF
--- a/app/controllers/retrospectives_controller.rb
+++ b/app/controllers/retrospectives_controller.rb
@@ -5,6 +5,7 @@ class RetrospectivesController < ApplicationController
 
   before_action :set_regime, only: [:index]
   before_action :set_transaction, only: [:show]
+  before_action :redirect_if_waste
 
   # GET /regimes/:regime_id/history
   # GET /regimes/:regime_id/history.json
@@ -51,6 +52,10 @@ class RetrospectivesController < ApplicationController
   end
 
   private
+    def redirect_if_waste
+      redirect_to regime_transactions_path(@regime) if @regime.waste?
+    end
+
     def present_transactions(transactions)
       Kaminari.paginate_array(presenter.wrap(transactions, current_user),
                               total_count: transactions.total_count,

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -32,12 +32,19 @@ module TransactionsHelper
   end
 
   def view_options(selected_mode)
-    options_for_select([
-      [t("transactions.index.title"), 'unbilled', { 'data-path' => regime_transactions_path(@regime) }],
-      [t("history.index.title"), 'historic', { 'data-path' => regime_history_index_path(@regime) }],
-      [t("retrospectives.index.title"), 'retrospective', { 'data-path' => regime_retrospectives_path(@regime) }],
-      [t("exclusions.index.title"), 'excluded', { 'data-path' => regime_exclusions_path(@regime) }]
-    ], selected_mode)
+    opts = [
+      [t("transactions.index.title"), 'unbilled',
+       { 'data-path' => regime_transactions_path(@regime) }],
+      [t("history.index.title"), 'historic',
+       { 'data-path' => regime_history_index_path(@regime) }],
+      [t("retrospectives.index.title"), 'retrospective',
+       { 'data-path' => regime_retrospectives_path(@regime) }],
+      [t("exclusions.index.title"), 'excluded',
+       { 'data-path' => regime_exclusions_path(@regime) }]
+    ]
+
+    opts = opts.select { |o| o[1] != 'retrospective' } if @regime.waste?
+    options_for_select opts, selected_mode
   end
 
   def per_page_options(selected = nil)

--- a/app/views/shared/menu/_transactions.html.erb
+++ b/app/views/shared/menu/_transactions.html.erb
@@ -4,21 +4,22 @@
      id="navbarTransactionsSelectorLink"
      data-toggle="dropdown"
      aria-haspopup="true"
-     aria-expanded="false">
-    Transactions
-  </a>
+     aria-expanded="false">Transactions</a>
+
   <div class="dropdown-menu" aria-labelledby="navbarTransactionsSelectorLink">
     <%= link_to t("title", scope: "transactions.index"),
       regime_transactions_path(@regime),
-      class: "dropdown-item" %>
+      class: "dropdown-item" -%>
     <%= link_to t("title", scope: "history.index"),
       regime_history_index_path(@regime),
-      class: "dropdown-item" %>
-    <%= link_to t("title", scope: "retrospectives.index"),
-      regime_retrospectives_path(@regime),
-      class: "dropdown-item" %>
+      class: "dropdown-item" -%>
+    <% unless @regime.waste? %>
+      <%= link_to t("title", scope: "retrospectives.index"),
+        regime_retrospectives_path(@regime),
+        class: "dropdown-item" -%>
+    <% end %>
     <%= link_to t("title", scope: "exclusions.index"),
       regime_exclusions_path(@regime),
-      class: "dropdown-item" %>
+      class: "dropdown-item" -%>
   </div>
 </li>

--- a/test/controllers/retrospectives_controller_test.rb
+++ b/test/controllers/retrospectives_controller_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper.rb'
+
+class RetrospectivesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @regime = regimes(:cfd)
+    sign_in users(:billing_admin)
+  end
+
+  def test_it_should_get_index
+    get regime_retrospectives_path(@regime)
+    assert_response :success
+  end
+
+  def test_it_should_redirect_to_transactions_index_for_waste
+    @regime = regimes(:wml)
+    sign_in users(:wml_billing_admin)
+    get regime_retrospectives_path(@regime)
+    assert_redirected_to regime_transactions_path(@regime)
+  end
+
+  def test_it_should_get_index_for_csv
+    get regime_retrospectives_path(@regime, format: :csv)
+    assert_response :success
+  end
+
+  def test_it_should_use_export_for_csv
+    csv = mock
+    csv.expects(:export).returns("test")
+    RetrospectivesController.any_instance.stubs(:csv).returns(csv)
+
+    get regime_retrospectives_path(@regime, format: :csv)
+  end
+end

--- a/test/fixtures/regime_users.yml
+++ b/test/fixtures/regime_users.yml
@@ -27,3 +27,8 @@ pas_bill:
   regime: pas
   user: pas_billing_admin
   enabled: true
+
+wml_bill:
+  regime: wml
+  user: wml_billing_admin
+  enabled: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -31,6 +31,14 @@ pas_billing_admin:
   encrypted_password: <%= Devise::Encryptor.digest(User, "Passw0rd") %>
   enabled: true
 
+wml_billing_admin:
+  role: 'billing'
+  email: "wml-billing@example.com"
+  first_name: "Hawkeye"
+  last_name: "Gladys"
+  encrypted_password: <%= Devise::Encryptor.digest(User, "Passw0rd") %>
+  enabled: true
+
 system_account:
   role: 'admin'
   email: "system@example.com"

--- a/test/integration/transaction_mode_selection_test.rb
+++ b/test/integration/transaction_mode_selection_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+class TransactionModeSelectionTest < ActionDispatch::IntegrationTest
+  def setup
+    @retro_text = "Pre-April 2018 Transactions to be billed"
+    @wml_options = [ "Transactions to be billed",
+                     "Transaction History",
+                     "Excluded Transactions" ]
+    @all_options = [ "Transactions to be billed",
+                     "Transaction History",
+                     @retro_text,
+                     "Excluded Transactions" ]
+  end
+
+  def test_transaction_main_menu_has_no_retrospective_option_for_waste
+    setup_wml
+    visit regime_transactions_path(@regime)
+    assert page.has_no_selector? "nav.main-menu a.dropdown-item",
+      text: @retro_text
+  end
+
+  def test_transaction_main_menu_has_retrospective_option_for_installations
+    setup_pas
+    visit regime_transactions_path(@regime)
+    assert page.has_selector? "nav.main-menu a.dropdown-item",
+      text: @retro_text
+  end
+
+  def test_transaction_main_menu_has_retrospective_option_for_water_quality
+    setup_cfd
+    visit regime_transactions_path(@regime)
+    assert page.has_selector? "nav.main-menu a.dropdown-item",
+      text: @retro_text
+  end
+
+  def test_view_selector_has_no_retrospective_option_for_waste
+    setup_wml
+    [ regime_transactions_path(@regime),
+      regime_history_index_path(@regime),
+      regime_exclusions_path(@regime) ].each do |path|
+        visit path
+        assert page.has_select? "mode", options: @wml_options
+      end
+  end
+
+  def test_view_selector_has_retrospective_option_for_installations
+    setup_pas
+    [ regime_transactions_path(@regime),
+      regime_history_index_path(@regime),
+      regime_retrospectives_path(@regime),
+      regime_exclusions_path(@regime) ].each do |path|
+        visit path
+        assert page.has_select? "mode", options: @all_options
+      end
+  end
+
+  def test_view_selector_has_retrospective_option_for_water_quality
+    setup_cfd
+    [ regime_transactions_path(@regime),
+      regime_history_index_path(@regime),
+      regime_retrospectives_path(@regime),
+      regime_exclusions_path(@regime) ].each do |path|
+        visit path
+        assert page.has_select? "mode", options: @all_options
+      end
+  end
+
+  def setup_cfd
+    @regime = regimes(:cfd)
+    @user = users(:billing_admin)
+    sign_in @user
+  end
+
+  def setup_pas
+    @regime = regimes(:pas)
+    @user = users(:pas_billing_admin)
+    sign_in @user
+  end
+
+  def setup_wml
+    @regime = regimes(:wml)
+    @user = users(:wml_billing_admin)
+    sign_in @user
+  end
+end


### PR DESCRIPTION
Waste regime do not pass retrospective transactions to us so there is no need for them to be able to access the pre-April 2018 transactions to be billed (retrospectives) view.
Removed the option from the main menu and view menu selector. Also redirect to transactions to be billed if switching regime to Waste from the retrospectives view.