### PR TITLE
Validation of pagination params

### DIFF
--- a/app/controllers/concerns/view_model_builder.rb
+++ b/app/controllers/concerns/view_model_builder.rb
@@ -46,6 +46,7 @@ module ViewModelBuilder
     vm.search = param_or_cookie(:search, '')
     vm.sort = param_or_cookie(:sort, 'customer_reference')
     vm.sort_direction = param_or_cookie(:sort_direction, 'asc')
+    vm.check_params
     vm
   end
 

--- a/app/models/view_models/transactions.rb
+++ b/app/models/view_models/transactions.rb
@@ -54,11 +54,28 @@ module ViewModels
     end
 
     def transactions
-      @transactions ||= fetch_transactions
+      @transactions ||= fetch_check_transactions
     end
 
     def paged_transactions
       @paged_transactions ||= transactions.page(page).per(per_page)
+    end
+
+    def check_params
+      @page = 1 if page.blank?
+      @page = 1 unless page.to_i.positive?
+      @per_page = 10 if per_page.blank?
+      @per_page = 10 unless per_page.to_i.positive?
+      # fetch transactions to validate/reset page
+      transactions
+    end
+
+    def fetch_check_transactions
+      t = fetch_transactions
+      pg = page.to_i
+      perp = per_page.to_i
+      @page = 1 if (pg * perp) > t.count
+      t
     end
 
     # override me for different views

--- a/test/integration/pagination_test.rb
+++ b/test/integration/pagination_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class PaginationTest < ActionDispatch::IntegrationTest
+  include RegimeSetup
+
+  def setup
+    Capybara.current_driver = Capybara.javascript_driver
+  end
+
+  def test_handle_page_too_big_for_ttbb
+    setup_cfd
+    visit regime_transactions_path(@regime, page: 10, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_small_for_ttbb
+    setup_cfd
+    visit regime_transactions_path(@regime, page: -13, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_big_for_history
+    setup_cfd
+    visit regime_history_index_path(@regime, page: 10, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_small_for_history
+    setup_cfd
+    visit regime_history_index_path(@regime, page: -110, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_big_for_retrospectives
+    setup_cfd
+    visit regime_retrospectives_path(@regime, page: 10, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_small_for_retrospectives
+    setup_cfd
+    visit regime_retrospectives_path(@regime, page: -1000, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_big_for_exclusions
+    setup_cfd
+    visit regime_exclusions_path(@regime, page: 10, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+
+  def test_handle_page_too_small_for_exclusions
+    setup_cfd
+    visit regime_exclusions_path(@regime, page: 0, per_page: 20)
+    assert page.has_selector? "div.tcm-table[data-page='1']"
+  end
+end


### PR DESCRIPTION
Scenario was occurring where user visits one data view and sets the current pagination page to a value larger than the subsequent data view she visits, causing no data to be displayed i.e. the page is set to 5 when only 2 pages of data are set.  Added validation in the `ViewModel` to check the params against the query performed and reset page to `1` if necessary.