### PR TITLE
Aligned cookie path to root, removed cookie reset code

### DIFF
--- a/app/assets/javascripts/cookie_policy.js
+++ b/app/assets/javascripts/cookie_policy.js
@@ -18,11 +18,11 @@ var CookiePolicy = (function () {
   function setMessageCookie () {
     var d = new Date()
     d.setYear(d.getFullYear() + 1)
-    document.cookie = cookieName + '=' + cookieValue + ';expires=' + d.toUTCString()
+    document.cookie = cookieName + '=' + cookieValue + ';path=/;expires=' + d.toUTCString()
   }
 
   function removeMessageCookie () {
-    var cookie = cookieName + '=; expires=' + new Date(0).toUTCString()
+    var cookie = cookieName + '=;path=/;expires=' + new Date(0).toUTCString()
     document.cookie = cookie
   }
 

--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -114,9 +114,9 @@ function set_cookie_data (container) {
 
 function safe_val(val) {
   if (typeof val === 'undefined' || val == null) {
-    return ''
+    return ';path=/'
   } else {
-    return val
+    return val + ';path=/'
   }
 }
 

--- a/app/controllers/concerns/regime_scope.rb
+++ b/app/controllers/concerns/regime_scope.rb
@@ -19,16 +19,16 @@ module RegimeScope
     last_id = cookies[:regime_id]
     r_id = params.fetch(:regime_id, nil)
 
-    if last_id && r_id != last_id
-      # switch regime - clear cookies
-      cookies.delete(:regime_id)
-      cookies.delete(:region)
-      cookies.delete(:search)
-      cookies.delete(:sort)
-      cookies.delete(:sort_direction)
-      cookies.delete(:page)
-      cookies.delete(:per_page)
-    end
+    # if last_id && r_id != last_id
+    #   # switch regime - clear cookies
+    #   cookies.delete(:regime_id)
+    #   cookies.delete(:region)
+    #   cookies.delete(:search)
+    #   cookies.delete(:sort)
+    #   cookies.delete(:sort_direction)
+    #   cookies.delete(:page)
+    #   cookies.delete(:per_page)
+    # end
 
     if r_id
       @regime = current_user.set_selected_regime(r_id)

--- a/test/integration/search_criteria_persistence_test.rb
+++ b/test/integration/search_criteria_persistence_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class SearchCriteriaPersistenceTest < ActionDispatch::IntegrationTest
+  include RegimeSetup
+
+  def setup
+    Capybara.current_driver = Capybara.javascript_driver
+  end
+
+  def test_sort_column_retained_after_exclusion
+    setup_pas
+    visit regime_transactions_path(@regime)
+    # make Original Permit the sort column
+    page.click_link "Original Permit"
+    wait_for_ajax
+    # sort descending z-a
+    page.click_link "Original Permit"
+    wait_for_ajax
+    # get more details for first row
+    page.first(".tcm-table tr.active button.show-details-button").click
+    # exclude this transaction
+    page.find_button("Exclude from Billing").click
+    # choose selected reason and exclude
+    page.find_button("Exclude Transaction").click
+    # put redirect get
+    page.find_button("Reinstate for Billing")
+    page.click_link("Back")
+    # back to TTBB
+    page.click_link("Back")
+    assert page.has_selector? "a.sorted.sorted-desc[data-column='original_permit_reference']", text: /Original Permit/
+  end
+end


### PR DESCRIPTION
Unable to recreate issue following instructions but observed similar issue.  Cookie path now always set to '/' to prevent multiple versions of the same cookie being created.