### PR TITLE
Using multiple historic text as outcome

### DIFF
--- a/app/services/permits/category_processor_base.rb
+++ b/app/services/permits/category_processor_base.rb
@@ -83,6 +83,16 @@ module Permits
       make_suggestion(where_args, :red, "No previous bill found", stage)
     end
 
+    def multiple_historic_matches(where_args, stage)
+      make_suggestion(where_args, :red,
+                      'Multiple historic matches found', stage)
+    end
+
+    def multiple_matching_transactions(where_args, stage)
+      make_suggestion(where_args, :red,
+                      "Multiple matching transactions found in file", stage)
+    end
+
     def set_logic_message(where_args, msg)
       unbilled_transactions(where_args) do |t|
         # FIXME: not using this now - only left until all

--- a/app/services/permits/pas_category_processor.rb
+++ b/app/services/permits/pas_category_processor.rb
@@ -60,7 +60,7 @@ module Permits
           if invoices.first.period_start != invoices.second.period_start
             set_category(transaction, invoices.first, :amber, stage)
           else
-            no_historic_transaction({ id: transaction.id }, stage)
+            multiple_historic_matches({ id: transaction.id }, stage)
           end
         end
       end
@@ -83,7 +83,7 @@ module Permits
           if invoices.first.period_start != invoices.second.period_start
             set_category(transaction, invoices.first, :green, stage, true)
           else
-            no_historic_transaction({ id: transaction.id }, stage)
+            multiple_historic_matches({ id: transaction.id }, stage)
           end
         end
       end
@@ -101,17 +101,6 @@ module Permits
         where(customer_reference: transaction.customer_reference).
         where(period_end: transaction.period_end).
         order(period_start: :desc)
-    end
-
-    def multiple_historic_matches(permit_args, stage)
-      make_suggestion(permit_args, :red,
-                      'Multiple historic matches found', stage)
-      # set_logic_message(permit_args, 'Multiple historic matches found')
-    end
-
-    def multiple_matching_transactions(permit_args, stage)
-      make_suggestion(permit_args, :red,
-                      "Multiple matching transactions found in file", stage)
     end
 
     def find_historic_transactions(args)

--- a/app/services/permits/wml_category_processor.rb
+++ b/app/services/permits/wml_category_processor.rb
@@ -56,7 +56,7 @@ module Permits
           if invoices.first.period_start != invoices.second.period_start
             set_category(transaction, invoices.first, :amber, stage)
           else
-            no_historic_transaction({ id: transaction.id }, stage)
+            multiple_historic_matches({ id: transaction.id }, stage)
           end
         end
       end
@@ -78,7 +78,7 @@ module Permits
           if invoices.first.period_start != invoices.second.period_start
             set_category(transaction, invoices.first, :green, stage, true)
           else
-            no_historic_transaction({ id: transaction.id }, stage)
+            multiple_historic_matches({ id: transaction.id }, stage)
           end
         end
       end

--- a/test/services/permits/pas_category_processor_test.rb
+++ b/test/services/permits/pas_category_processor_test.rb
@@ -293,7 +293,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
 
     assert_nil t.category, "Category set!"
     sg = t.suggested_category
-    assert_equal('No previous bill found', sg.logic)
+    assert_equal('Multiple historic matches found', sg.logic)
     assert_equal('Supplementary invoice stage 2', sg.suggestion_stage)
     refute sg.admin_lock?, "It is admin locked"
     assert sg.red?
@@ -373,7 +373,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
 
     assert_nil t.category, "Category set!"
     sg = t.suggested_category
-    assert_equal('No previous bill found', sg.logic)
+    assert_equal('Multiple historic matches found', sg.logic)
     assert_equal('Supplementary credit stage 2', sg.suggestion_stage)
     refute sg.admin_lock?, "It is admin locked"
     assert sg.red?

--- a/test/services/permits/wml_category_processor_test.rb
+++ b/test/services/permits/wml_category_processor_test.rb
@@ -237,7 +237,7 @@ class WmlCategoryProcessorTest < ActiveSupport::TestCase
 
     assert_nil t.category, "Category set!"
     sg = t.suggested_category
-    assert_equal('No previous bill found', sg.logic)
+    assert_equal('Multiple historic matches found', sg.logic)
     assert_equal('Supplementary invoice stage 2', sg.suggestion_stage)
     refute sg.admin_lock?, "It is admin locked"
     assert sg.red?
@@ -311,7 +311,7 @@ class WmlCategoryProcessorTest < ActiveSupport::TestCase
 
     assert_nil t.category, "Category set!"
     sg = t.suggested_category
-    assert_equal('No previous bill found', sg.logic)
+    assert_equal('Multiple historic matches found', sg.logic)
     assert_equal('Supplementary credit stage 2', sg.suggestion_stage)
     refute sg.admin_lock?, "It is admin locked"
     assert sg.red?


### PR DESCRIPTION
For Installations and Waste during supplementary billing if the processor could not identify a unique historic transaction to match with it would report `"No historic bill found"`, this has been updated to `"Multiple historic matches found"` in the instances where there are multiple matches.
This has not been implemented for Water Quality as there doesn't seem to be a process flow where this would apply (yet).