### PR TITLE
Fix for issue with intensive farming compliance band

### DIFF
--- a/app/presenters/pas_transaction_detail_presenter.rb
+++ b/app/presenters/pas_transaction_detail_presenter.rb
@@ -25,14 +25,15 @@ class PasTransactionDetailPresenter < TransactionDetailPresenter
   # end
 
   def compliance_band_adjustment
-    band = extract_compliance_performance
-    return "" if band.nil?
-    d = band.match /\A.*\((\d+%)\)\z/
-    if d.size == 2
-      d[1]
-    else
-      ""
-    end
+    tcm_compliance_percentage
+    # band = extract_compliance_performance
+    # return "" if band.nil?
+    # d = band.match /\A.*\((\d+%)\)\z/
+    # if d.size == 2
+    #   d[1]
+    # else
+    #   ""
+    # end
   end
 
   # Moved to base class

--- a/app/presenters/transaction_detail_presenter.rb
+++ b/app/presenters/transaction_detail_presenter.rb
@@ -295,10 +295,10 @@ class TransactionDetailPresenter < SimpleDelegator
 
   def tcm_compliance_percentage
     band = extract_compliance_performance
-    return "" if band.nil?
+    return "" if band.blank? || band == "()"
 
     d = band.match /\A.*\((\d+%)\)\z/
-    d.size == 2 ? d[1] : ""
+    d && d.size == 2 ? d[1] : ""
   end
 
   def confidence_level


### PR DESCRIPTION
Changes in the rules for the intensive faming compliance band adjustment has caused an issue with parsing the compliance band as it now longer matches our regex. This should fix that.