### PR TITLE
Remove turbolinks from download link

### DIFF
--- a/app/views/data_export/_export_data_file.html.erb
+++ b/app/views/data_export/_export_data_file.html.erb
@@ -16,13 +16,13 @@
   <div class="mt-4">
     <%= link_to "Agree and Download Transaction Data",
       download_regime_data_export_index_path(@regime),
-      class: "btn btn-primary" %>
+      class: "btn btn-primary", data: { turbolinks: false } %>
   </div>
 <% end %>
 <% if SystemConfig.config.can_generate_export? %>
   <div class="mt-4">
     <%= link_to "TEST: Regenerate Export File",
       generate_regime_data_export_index_path(@regime),
-      class: "btn btn-warning" %>
+      class: "btn btn-warning", data: { turbolinks: false } %>
   </div>
 <% end %>


### PR DESCRIPTION
Clicking new download link was creating a blank page in IE11. Preventing turbolinks from using the link has resolved the issued.