### PR TITLE
Fixed issue with pre_sroc_flag

### DIFF
--- a/app/models/transaction_detail.rb
+++ b/app/models/transaction_detail.rb
@@ -108,6 +108,10 @@ class TransactionDetail < ApplicationRecord
     status == 'retrospective'
   end
 
+  def billed_retrospective?
+    status == 'retro_billed'
+  end
+
   def permanently_excluded?
     status == 'excluded'
   end

--- a/app/presenters/transaction_detail_presenter.rb
+++ b/app/presenters/transaction_detail_presenter.rb
@@ -145,7 +145,7 @@ class TransactionDetailPresenter < SimpleDelegator
   end
 
   def pre_sroc_flag
-    transaction_detail.retrospective? ? 'Y' : 'N'
+    (retrospective? || billed_retrospective?) ? 'Y' : 'N'
   end
 
   def excluded_flag

--- a/test/presenters/cfd_transaction_detail_presenter_test.rb
+++ b/test/presenters/cfd_transaction_detail_presenter_test.rb
@@ -120,6 +120,16 @@ class CfdTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal("Discharge Location: ", @presenter.discharge_location)
   end
 
+  def test_pre_sroc_flag_returns_Y_for_retrospective_transactions
+    @transaction.status = 'retrospective'
+    assert_equal 'Y', @presenter.pre_sroc_flag, "Pre-SRoC flag incorrect"
+  end
+
+  def test_pre_sroc_flag_returns_Y_for_retro_billed_transactions
+    @transaction.status = 'retro_billed'
+    assert_equal 'Y', @presenter.pre_sroc_flag, "Pre-SRoC flag incorrect"
+  end
+
   def test_it_transforms_into_json
     assert_equal({
       id: @transaction.id,

--- a/test/presenters/pas_transaction_detail_presenter_test.rb
+++ b/test/presenters/pas_transaction_detail_presenter_test.rb
@@ -50,6 +50,16 @@ class PasTransactionDetailPresenterTest < ActiveSupport::TestCase
     assert_equal(addr, @presenter.site_address)
   end
 
+  def test_pre_sroc_flag_returns_Y_for_retrospective_transactions
+    @transaction.status = 'retrospective'
+    assert_equal 'Y', @presenter.pre_sroc_flag, "Pre-SRoC flag incorrect"
+  end
+
+  def test_pre_sroc_flag_returns_Y_for_retro_billed_transactions
+    @transaction.status = 'retro_billed'
+    assert_equal 'Y', @presenter.pre_sroc_flag, "Pre-SRoC flag incorrect"
+  end
+
   def test_it_transforms_into_json
     assert_equal(
       {


### PR DESCRIPTION
Fixed issue where the `pre_sroc_flag` method didn't consider transactions with status of `retro_billed` and so these resulted in 'N' being returned instead of 'Y'.