### PR TITLE
Approve all now uses financial year

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -87,6 +87,11 @@ class TransactionsController < ApplicationController
     regions = Query::Regions.call(regime: @regime)
     # regions = transaction_store.unbilled_regions
     @region = params.fetch(:region, cookies[:region])
+    fy = params.fetch(:fy, cookies[:fy])
+    
+    available_years = Query::FinancialYears.call(regime: @regime)
+    fy = '' unless available_years.include? fy
+
     msg = ""
     
     result = if regions.include? @region
@@ -103,6 +108,7 @@ class TransactionsController < ApplicationController
       q = params.fetch(:search, '')
       approval = ApproveMatchingTransactions.call(regime: @regime,
                                                   region: @region,
+                                                  financial_year: fy,
                                                   search: q,
                                                   user: current_user)
       result = approval.success?

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,25 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Cross-Site Request Forgery",
+      "warning_code": 7,
+      "fingerprint": "81654be028fa219953df42b67b1eb44466ef3d69b9400695b411bec8755e5bff",
+      "check_name": "ForgerySetting",
+      "message": "'protect_from_forgery' should be called in ErrorsController",
+      "file": "app/controllers/errors_controller.rb",
+      "line": 2,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/",
+      "code": null,
+      "render_path": null,
+      "location": {
+        "type": "controller",
+        "controller": "ErrorsController"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "note": ""
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
       "fingerprint": "8d3c7949294a38e3a67fac03b2fcd8a838523c198baebc2cc53a2605ddf7eb90",
@@ -19,8 +38,28 @@
       "user_input": ":role",
       "confidence": "Medium",
       "note": "Controller access is restricted so only admin role can update :role attribute (or any user attribute)"
+    },
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "ee6e51a7de8043179d84993b6b6e00f6b3901239b094158160657432c40e3de2",
+      "check_name": "SendFile",
+      "message": "Parameter value used in file name",
+      "file": "app/controllers/data_export_controller.rb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file(FetchDataExportFile.call(:regime => ((current_user.set_selected_regime(params.fetch(:regime_id, nil)) or current_user.selected_regime))).filename)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "DataExportController",
+        "method": "download"
+      },
+      "user_input": "params.fetch(:regime_id, nil)",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2018-04-12 11:06:38 +0100",
-  "brakeman_version": "4.2.1"
+  "updated": "2019-01-16 14:47:41 +0000",
+  "brakeman_version": "4.3.1"
 }

--- a/test/services/approve_matching_transactions_test.rb
+++ b/test/services/approve_matching_transactions_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper.rb'
+
+class ApproveMatchingTransactionsTest < ActiveSupport::TestCase
+  include RegimePresenter, ChargeCalculation, GenerateHistory
+
+  def setup
+    @regime = regimes(:cfd)
+    @user = users(:billing_admin)
+  end
+
+  def test_it_uses_financial_year_when_specified
+    t = @regime.transaction_details.unbilled.last
+    tt = t.dup
+    tt.tcm_financial_year = '1920'
+    tt.charge_calculation = dummy_charge
+    tt.tcm_charge = 1234
+    tt.save!
+
+    result = ApproveMatchingTransactions.call(regime: @regime,
+                                              region: tt.region,
+                                              financial_year: '1819',
+                                              search: '',
+                                              user: @user)
+    assert result.success?, "Failed to approve"
+    refute tt.reload.approved_for_billing?, "Approved but shouldn't be"
+
+    result = ApproveMatchingTransactions.call(regime: @regime,
+                                              region: tt.region,
+                                              financial_year: '1920',
+                                              search: '',
+                                              user: @user)
+    assert result.success?, "Failed to approve"
+    assert tt.reload.approved_for_billing?, "Unapproved but should be"
+  end
+end
+


### PR DESCRIPTION
Financial year filter wasn't being considered in query for 'approve all' functionality.