### PR TITLE
Batched queries for dynamic csv generation

### DIFF
--- a/app/controllers/concerns/csv_exporter.rb
+++ b/app/controllers/concerns/csv_exporter.rb
@@ -2,10 +2,22 @@ module CsvExporter
   extend ActiveSupport::Concern
 
   # :nocov:
-  def csv_opts
+
+  def set_streaming_headers
+    headers["Content-Type"] = "text/csv"
+    headers["Content-disposition"] = "attachment; filename=\"#{csv_filename}\""
+    headers["X-Accel-Buffering"] = "no"
+    headers.delete("Content-Length")
+  end
+
+  def csv_filename
     ts = Time.zone.now.strftime("%Y%m%d%H%M%S")
+    "#{controller_name}_#{ts}.csv"
+  end
+
+  def csv_opts
     {
-      filename: "#{controller_name}_#{ts}.csv",
+      filename: csv_filename,
       type: :csv
     }
   end

--- a/app/controllers/exclusions_controller.rb
+++ b/app/controllers/exclusions_controller.rb
@@ -15,12 +15,18 @@ class ExclusionsController < ApplicationController
       format.html do
         if request.xhr?
           render partial: 'table', locals: { view_model: @view_model }
-        else
-          render
         end
       end
       format.csv do
-        send_data csv.full_export(@view_model.csv_transactions), csv_opts
+        result = BatchCsvExport.call(regime: @regime,
+                                     query: @view_model.fetch_transactions)
+        if result.success?
+          set_streaming_headers
+          self.response_body = result.csv_stream
+        end
+        # set_streaming_headers
+        # self.response_body = stream_csv_data(@view_model.fetch_transactions)
+        # send_data csv.full_export(@view_model.csv_transactions), csv_opts
       end
     end
   end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -18,7 +18,16 @@ class HistoryController < ApplicationController
         end
       end
       format.csv do
-        send_data csv.full_export(@view_model.csv_transactions), csv_opts
+        result = BatchCsvExport.call(regime: @regime,
+                                     query: @view_model.fetch_transactions)
+        if result.success?
+          set_streaming_headers
+          self.response_body = result.csv_stream
+        end
+        # set_streaming_headers
+        # self.response_body = stream_csv_data(@view_model.fetch_transactions)
+
+        # send_data csv.full_export(@view_model.csv_transactions), csv_opts
       end
     end
   end

--- a/app/controllers/retrospectives_controller.rb
+++ b/app/controllers/retrospectives_controller.rb
@@ -16,12 +16,17 @@ class RetrospectivesController < ApplicationController
       format.html do
         if request.xhr?
           render partial: 'table', locals: { view_model: @view_model }
-        else
-          render
         end
       end
       format.csv do
-        send_data csv.full_export(@view_model.csv_transactions), csv_opts
+        result = BatchCsvExport.call(regime: @regime,
+                                     query: @view_model.fetch_transactions)
+        if result.success?
+          set_streaming_headers
+          self.response_body = result.csv_stream
+        end
+        # self.response_body = stream_csv_data(@view_model.fetch_transactions)
+        # send_data csv.full_export(@view_model.csv_transactions), csv_opts
       end
     end
   end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -18,7 +18,15 @@ class TransactionsController < ApplicationController
         end
       end
       format.csv do
-        send_data csv.full_export(@view_model.csv_transactions), csv_opts
+        result = BatchCsvExport.call(regime: @regime,
+                                     query: @view_model.fetch_transactions)
+        if result.success?
+          set_streaming_headers
+          self.response_body = result.csv_stream
+        end
+        # set_streaming_headers
+        # self.response_body = stream_csv_data(@view_model.fetch_transactions)
+        # send_data csv.full_export(@view_model.csv_transactions), csv_opts
       end
     end
   end

--- a/app/services/batch_csv_export.rb
+++ b/app/services/batch_csv_export.rb
@@ -1,0 +1,61 @@
+require 'csv'
+
+class BatchCsvExport < ServiceObject
+  include RegimePresenter
+
+  attr_reader :regime, :query, :csv_stream, :max_limit, :batch_size
+
+  def initialize(params = {})
+    @regime = params.fetch(:regime)
+    @query = params.fetch(:query)
+    @max_limit = params.fetch(:max_limit, 15000)
+    @batch_size = params.fetch(:batch_size, 1000)
+    @csv_stream = nil
+  end
+
+  def call
+    @csv_stream = Enumerator.new do |y|
+      y << csv_headers
+
+      batch_query do |t|
+        y << csv_row(t)
+      end 
+    end
+
+    @result = true
+    self
+  end
+
+  private
+
+  def batch_query(&block)
+    count = query.count
+    count = [ count, max_limit ].min unless max_limit.zero?
+
+    offset = 0
+    while offset < count do
+      query.offset(offset).limit(batch_size).each do |transaction|
+        yield transaction
+      end
+      offset += batch_size
+    end
+  end
+
+  def csv_headers
+    CSV::Row.new(regime_columns, regime_headings, true).to_s
+  end
+
+  def csv_row(transaction)
+    t = presenter.new(transaction)
+    values = regime_columns.map { |c| t.send(c) }
+    CSV::Row.new(regime_columns, values).to_s
+  end
+
+  def regime_headings
+    ExportFileFormat::ExportColumns.map { |c| c[:heading] }
+  end
+
+  def regime_columns
+    @regime_columns ||= ExportFileFormat::ExportColumns.map { |c| c[:accessor] }
+  end
+end


### PR DESCRIPTION
Reduce memory overhead for dynamic csv export queries by loading query rows in batches and streaming csv results back to client as they are rendered