### PR TITLE
Added compressed file message for download

### DIFF
--- a/app/views/data_export/index.html.erb
+++ b/app/views/data_export/index.html.erb
@@ -6,6 +6,7 @@
 <div class="row">
   <div class="col col-lg-6">
     <% content_for :dp_content do %>
+      <p>The export process produces compressed data files. Use 7-Zip or a similar application to open files of this type.</p>
       <%= render partial: 'export_data_file',
         locals: { export_data_file: @regime.export_data_file } %>
     <% end %>


### PR DESCRIPTION
Added message to inform users to use 7-zip or similar to uncompress the overnight data export files.
7-zip is part of the standard Windows build on the user's PCs but not necessarily associated with the `.gz` files automatically.