### PR TITLE
Added checkbox confirmation to summary

### DIFF
--- a/app/assets/javascripts/transactions.js
+++ b/app/assets/javascripts/transactions.js
@@ -100,6 +100,15 @@ function fetch_summary_and_show (container) {
     },
     success: function (payload, status, xhr) {
       $("#summary-dialog").replaceWith(payload)
+      $('#summary-dialog #confirm:not(:disabled)').on('click', function (ev) {
+        if ($(this).is(':checked')) {
+          // enable generate button
+          $("#summary-dialog input.file-generate-btn").prop('disabled', false)
+        } else {
+          // disable generate button
+          $("#summary-dialog input.file-generate-btn").prop('disabled', true)
+        }
+      })
       $("#summary-dialog").modal()
     },
     dataType: 'html'

--- a/app/views/shared/_summary_dialog.html.erb
+++ b/app/views/shared/_summary_dialog.html.erb
@@ -42,15 +42,22 @@
             </div>
           </div>
         <% end %>
+        <% has_transactions = summary.has_transactions_to_bill? %>
+        <div class='row'>
+          <div class='col form-check'>
+            <label class='form-check-label <%= 'text-muted' unless has_transactions %>' for='confirm'>I have checked the summary and wish to proceed</label>
+            <input type='checkbox'
+                   class="form-check-input ml-2"
+                   name='confirm'
+                   id='confirm'
+                   <%= "disabled" unless has_transactions %> >
+          </div>
+        </div>
       </div>
       <div class='modal-footer'>
         <%= form_tag summary.path, method: "post" do %>
           <%= hidden_field_tag(:region, @region) %>
-          <% if summary.has_transactions_to_bill? %>
-            <%= submit_tag summary.title, class: 'btn btn-primary' %>
-          <% else %>
-            <span class='btn btn-primary disabled'><%= summary.title %></span>
-          <% end %>
+          <%= submit_tag summary.title, class: 'btn btn-primary file-generate-btn', disabled: true %>
           <button type='button' class='btn btn-secondary' data-dismiss='modal'>
             Cancel
           </button>


### PR DESCRIPTION
Added confirmation step before generation of files in the form of a checkbox added to the file summary / pre-2018 file summary that must be checked to enable the "Generate" button.