### PR TITLE
Split file handling up to cope with two s3 buckets

### DIFF
--- a/app/jobs/annual_billing_data_import_job.rb
+++ b/app/jobs/annual_billing_data_import_job.rb
@@ -7,12 +7,16 @@ class AnnualBillingDataImportJob < ApplicationJob
       user = User.find(user_id)
 
       regime = upload.regime
-      storage = FileStorageService.new
+      # storage = FileStorageService.new
       data_service = AnnualBillingDataFileService.new(regime, user)
 
       # fetch stored file
       file = Tempfile.new
-      storage.fetch_file_from(:annual_billing_data, upload.filename, file.path)
+
+      GetAnnualBillingDataFile.call(remote_path: upload.filename,
+                                    local_path: file.path)
+
+      # storage.fetch_file_from(:annual_billing_data, upload.filename, file.path)
       file.rewind
 
       # process stored file

--- a/app/jobs/regime_transaction_export_job.rb
+++ b/app/jobs/regime_transaction_export_job.rb
@@ -10,8 +10,7 @@ class RegimeTransactionExportJob < ApplicationJob
         TcmLogger.error("Failed to export transactions for #{regime.name}")
       else
         # store file
-        result = StoreDataExportFile.call(regime: regime,
-                                          filename: result.filename)
+        result = PutDataExportFile.call(filename: result.filename)
         TcmLogger.error("Failed to store export data file for #{regime.name}") if result.failed?
       end
     end

--- a/app/lib/archive_file_store.rb
+++ b/app/lib/archive_file_store.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ArchiveFileStore < AwsFileStore
+  def s3_bucket_name
+    ENV["ARCHIVE_BUCKET"]
+  end
+end

--- a/app/lib/etl_file_store.rb
+++ b/app/lib/etl_file_store.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class EtlFileStore < AwsFileStore
+end

--- a/app/lib/file_storage.rb
+++ b/app/lib/file_storage.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module FileStorage
+  def etl_file_store
+    if Rails.env.development? || Rails.env.test?
+      LocalFileStore.new("etl_bucket")
+    else
+      EtlFileStore.new
+    end
+  end
+
+  def archive_file_store
+    if Rails.env.development? || Rails.env.test?
+      LocalFileStore.new("archive_bucket")
+    else
+      ArchiveFileStore.new
+    end
+  end
+end

--- a/app/lib/local_file_store.rb
+++ b/app/lib/local_file_store.rb
@@ -2,6 +2,13 @@
 require "fileutils"
 
 class LocalFileStore
+  attr_reader :base_path
+
+  def initialize(base_path = "")
+    @base_path = Rails.root.join("tmp", "files", base_path)
+    FileUtils.mkdir_p @base_path unless Dir.exist? @base_path
+  end
+
   def list(path = "")
     file_root = Pathname.new(file_path(""))
     Dir.glob(File.join(file_path(path), "**", "*")).select { |f| File.file?(f) }.map {|f| Pathname.new(f).relative_path_from(file_root).to_s }
@@ -36,6 +43,7 @@ class LocalFileStore
   end
 private
   def file_path(path)
-    Rails.root.join("tmp", "files", path)
+    File.join(@base_path, path)
+    # Rails.root.join("tmp", "files", path)
   end
 end

--- a/app/lib/tcm_utils.rb
+++ b/app/lib/tcm_utils.rb
@@ -79,5 +79,8 @@ class TcmUtils
       dates << Date.strptime(d, date_format)
     end
     dates
+  rescue ArgumentError => e
+    Rails.logger.warn("Error in period date: [#{period}] - format: [#{date_format}]")
+    raise
   end
 end

--- a/app/services/annual_billing_data_file_service.rb
+++ b/app/services/annual_billing_data_file_service.rb
@@ -28,7 +28,9 @@ class AnnualBillingDataFileService
           # upload to S3
           filename = File.basename(data_file.original_filename)
           dest_file = File.join(storage_path, filename)
-          storage.store_file_in(:annual_billing_data, data_file.tempfile.path, dest_file)
+          PutAnnualBillingDataFile.call(local_path: data_file.tempfile.path,
+                                        remote_path: dest_file)
+          # storage.store_file_in(:annual_billing_data, data_file.tempfile.path, dest_file)
           record.filename = dest_file
           record.state.upload!
         rescue => e
@@ -77,9 +79,9 @@ class AnnualBillingDataFileService
     send("#{regime.to_param}_columns")
   end
 
-  def storage
-    @storage ||= FileStorageService.new
-  end
+  # def storage
+  #   @storage ||= FileStorageService.new
+  # end
 
   def storage_path
     File.join(regime.to_param, Time.zone.now.strftime("%Y%m%d%H%M%S"))

--- a/app/services/delete_etl_import_file.rb
+++ b/app/services/delete_etl_import_file.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class DeleteEtlImportFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @remote_path = params.fetch(:remote_path)
+  end
+
+  def call
+    etl_file_store.delete_file(@remote_path)
+    @result = true
+    self
+  end
+end
+

--- a/app/services/fetch_data_export_file.rb
+++ b/app/services/fetch_data_export_file.rb
@@ -26,7 +26,9 @@ class FetchDataExportFile < ServiceObject
     return cached_filename if cached_file_matches_stored_hash?(cached_filename)
 
     # pull file from S3
-    storage.fetch_file_from(:csv_export, file, cached_filename)
+    GetDataExportFile.call(remote_path: file,
+                           local_path: cached_filename)
+    # storage.fetch_file_from(:csv_export, file, cached_filename)
 
     # verify checksum
     raise RuntimeError.new("Checksum does not match stored file") unless check_file_hash(cached_filename)
@@ -56,7 +58,7 @@ class FetchDataExportFile < ServiceObject
     path
   end
 
-  def storage
-    @storage ||= FileStorageService.new
-  end
+  # def storage
+  #   @storage ||= FileStorageService.new
+  # end
 end

--- a/app/services/get_annual_billing_data_file.rb
+++ b/app/services/get_annual_billing_data_file.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class GetAnnualBillingDataFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @remote_path = params.fetch(:remote_path)
+    @local_path = params.fetch(:local_path)
+  end
+
+  def call
+    archive_file_store.fetch_file(annual_billing_path, @local_path)
+    @result = true
+    self
+  end
+
+  private
+
+  def annual_billing_path
+    File.join("annual_billing_data", @remote_path)
+  end
+end

--- a/app/services/get_data_export_file.rb
+++ b/app/services/get_data_export_file.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class GetDataExportFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @remote_path = params.fetch(:remote_path)
+    @local_path = params.fetch(:local_path)
+  end
+
+  def call
+    archive_file_store.fetch_file(data_export_path, @local_path)
+    @result = true
+    self
+  end
+
+  private
+
+  def data_export_path
+    File.join("csv", @remote_path)
+  end
+end

--- a/app/services/get_etl_import_file.rb
+++ b/app/services/get_etl_import_file.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class GetEtlImportFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @remote_path = params.fetch(:remote_path)
+    @local_path = params.fetch(:local_path)
+  end
+
+  def call
+    etl_file_store.fetch_file(@remote_path, @local_path)
+    @result = true
+    self
+  end
+end

--- a/app/services/list_etl_import_files.rb
+++ b/app/services/list_etl_import_files.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ListEtlImportFiles < ServiceObject
+  include FileStorage
+
+  attr_reader :files
+
+  def initialize(params = {})
+    @files = []
+  end
+
+  def call
+    @files = etl_file_store.list('import').reject do |f|
+      # reject any "directories"
+      f.end_with?(File::Separator)
+    end
+
+    @result = true
+    self
+  end
+end

--- a/app/services/put_annual_billing_data_file.rb
+++ b/app/services/put_annual_billing_data_file.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PutAnnualBillingDataFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @local_path = params.fetch(:local_path)
+    @remote_path = params.fetch(:remote_path)
+  end
+
+  def call
+    # store file in archive bucket
+    archive_file_store.store_file(@local_path, annual_billing_path)
+    @result = true
+    self
+  end
+
+  private
+
+  def annual_billing_path
+    File.join("annual_billing_data", @remote_path)
+  end
+end

--- a/app/services/put_archive_export_file.rb
+++ b/app/services/put_archive_export_file.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PutArchiveExportFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @local_path = params.fetch(:local_path)
+    @remote_path = params.fetch(:remote_path)
+  end
+
+  def call
+    # store file in archive bucket
+    archive_file_store.store_file(@local_path, export_path)
+    @result = true
+    self
+  end
+
+  private
+
+  def export_path
+    File.join("export", @remote_path)
+  end
+end

--- a/app/services/put_archive_import_file.rb
+++ b/app/services/put_archive_import_file.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PutArchiveImportFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @local_path = params.fetch(:local_path)
+    @remote_path = params.fetch(:remote_path)
+  end
+
+  def call
+    archive_file_store.store_file(@local_path, @remote_path)
+    @result = true
+    self
+  end
+end

--- a/app/services/put_data_export_file.rb
+++ b/app/services/put_data_export_file.rb
@@ -1,9 +1,9 @@
-class StoreDataExportFile < ServiceObject
+class PutDataExportFile < ServiceObject
+  include FileStorage
 
-  attr_reader :regime, :filename
+  attr_reader :filename
 
   def initialize(params = {})
-    @regime = params.fetch(:regime)
     @filename = params.fetch(:filename)
   end
 
@@ -13,9 +13,7 @@ class StoreDataExportFile < ServiceObject
       basename = File.basename(filename)
 
       begin
-        storage.store_file_in(:csv_export,
-                              filename,
-                              File.basename(filename))
+        archive_file_store.store_file(filename, csv_path)
 
         @result = true
       rescue => e
@@ -31,7 +29,7 @@ class StoreDataExportFile < ServiceObject
 
   private
 
-  def storage
-    @storage ||= FileStorageService.new
+  def csv_path
+    File.join('csv', File.basename(filename))
   end
 end

--- a/app/services/put_export_file.rb
+++ b/app/services/put_export_file.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PutExportFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @local_path = params.fetch(:local_path)
+    @remote_path = params.fetch(:remote_path)
+  end
+
+  def call
+    # store file in ETL bucket
+    etl_file_store.store_file(@local_path, export_path)
+    @result = true
+    self
+  end
+
+  private
+
+  def export_path
+    File.join("export", @remote_path)
+  end
+end

--- a/app/services/put_quarantine_file.rb
+++ b/app/services/put_quarantine_file.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Moves a file from the ETL bucket to the Archive bucket quarantine folder
+class PutQuarantineFile < ServiceObject
+  include FileStorage
+
+  def initialize(params = {})
+    @local_path = params.fetch(:local_path)
+    @remote_path = params.fetch(:remote_path)
+  end
+
+  def call
+    archive_file_store.store_file(@local_path, quarantine_path)
+    @result = true
+    self
+  end
+
+  private
+
+  def quarantine_path
+    File.join('quarantine', File.basename(@remote_path))
+  end
+end

--- a/app/services/transaction_file_exporter.rb
+++ b/app/services/transaction_file_exporter.rb
@@ -107,8 +107,12 @@ class TransactionFileExporter
     # make footer
     # update transactions status
     # write file and copy to S3
-    storage.store_file_in(:export, out_file.path, tf.path)
-    storage.store_file_in(:export_archive, out_file.path, tf.path)
+    PutExportFile.call(local_path: out_file.path,
+                       remote_path: tf.path)
+    PutArchiveExportFile.call(local_path: out_file.path,
+                              remote_path: tf.path)
+    # storage.store_file_in(:export, out_file.path, tf.path)
+    # storage.store_file_in(:export_archive, out_file.path, tf.path)
 
     attrs = {
       generated_filename: tf.base_filename,
@@ -286,9 +290,9 @@ class TransactionFileExporter
     end
   end
 
-  def storage
-    @storage ||= FileStorageService.new
-  end
+  # def storage
+  #   @storage ||= FileStorageService.new
+  # end
 
   def permit_store
     @permit_store ||= PermitStorageService.new(regime)


### PR DESCRIPTION
Added second s3 bucket to cope with limitation of the ETL processes that cannot manage the 1000 object paging limit on s3.  Existing bucket is now only used for ETL import/export so should mainly stay empty. The new bucket is used for all other file storage and archive purposes.