### PR TITLE
Renamed invoice to debit and fixed sorting of credit/debit column

### DIFF
--- a/app/presenters/transaction_detail_presenter.rb
+++ b/app/presenters/transaction_detail_presenter.rb
@@ -229,10 +229,10 @@ class TransactionDetailPresenter < SimpleDelegator
     txt = if line_amount.negative?
             'Credit'
           else
-            'Invoice'
+            'Debit'
           end
 
-    txt += ' (TBC)' if status != 'excluded'
+    txt += ' (TBC)' unless status == 'excluded'
     txt
   end
 

--- a/app/services/query/sort_transactions.rb
+++ b/app/services/query/sort_transactions.rb
@@ -60,6 +60,8 @@ module Query
           order("transaction_files.created_at #{dir}, tcm_transaction_reference #{dir}")
       when :amount
         q.order(tcm_charge: dir, id: dir)
+      when :credit_debit
+        q.order(line_amount: dir, id: dir)
       when :excluded_reason
         q.order(excluded_reason: dir, reference_1: dir)
       when :temporary_cessation

--- a/app/views/exclusions/_cfd_table.html.erb
+++ b/app/views/exclusions/_cfd_table.html.erb
@@ -11,7 +11,7 @@
       <th><%= sortable :variation, view_model %></th>
       <th><%= sortable :period, view_model %></th>
       <th><%= sortable :excluded_reason, view_model %></th>
-      <th class="text-right"><%= sortable :amount, view_model %></th>
+      <th class="text-right"><%= sortable :credit_debit, view_model %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/exclusions/_pas_table.html.erb
+++ b/app/views/exclusions/_pas_table.html.erb
@@ -10,7 +10,7 @@
       <th><%= sortable :compliance_band, view_model %></th>
       <th><%= sortable :period, view_model %></th>
       <th><%= sortable :excluded_reason, view_model %></th>
-      <th class="text-right"><%= sortable :amount, view_model %></th>
+      <th class="text-right"><%= sortable :credit_debit, view_model %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/exclusions/_wml_table.html.erb
+++ b/app/views/exclusions/_wml_table.html.erb
@@ -9,7 +9,7 @@
       <th><%= sortable :compliance_band, view_model %></th>
       <th><%= sortable :period, view_model %></th>
       <th><%= sortable :excluded_reason, view_model %></th>
-      <th class="text-right"><%= sortable :amount, view_model %></th>
+      <th class="text-right"><%= sortable :credit_debit, view_model %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/shared/_summary_dialog.html.erb
+++ b/app/views/shared/_summary_dialog.html.erb
@@ -23,9 +23,9 @@
                 <dd><%= summary.credit_count %><dd>
                 <dt>Value of credits</dt>
                 <dd><%= summary.credit_total %><dd>
-                <dt>Number of invoices</dt>
+                <dt>Number of debits</dt>
                 <dd><%= summary.invoice_count %><dd>
-                <dt>Value of invoices</dt>
+                <dt>Value of debits</dt>
                 <dd><%= summary.invoice_total %><dd>
                 <dt>Net amount to be billed</dt>
                 <dd><%= summary.net_total %><dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
         variation: "%"
         period: "Period"
         excluded_reason: "Exclusion Reason"
-        amount: "Credit/Invoice"
+        credit_debit: "Credit/Debit"
       users:
         last_name: 'Last Name'
         first_name: 'First Name'


### PR DESCRIPTION
Renamed occurrences of the word "Invoice" to "Debit" after feedback from the business. Also spotted that the "Credit/Debit" column on the "Excluded Transactions" view wasn't sorting correctly so fixed that too.