### PR TITLE
Added Google Tag Manager to base layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,16 @@
     <title>Tactical Charging Module Administration</title>
     <%= csrf_meta_tags %>
 
+    <% if ENV['GTM_CODE'] %>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<%= ENV['GTM_CODE'] %>');</script>
+<!-- End Google Tag Manager -->
+    <% end %>
+
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
@@ -14,6 +24,13 @@
   </head>
 
   <body>
+    <% if ENV['GTM_CODE'] %>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= ENV['GTM_CODE'] %>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+    <% end %>
+
     <div class="container-fluid">
       <%= render "layouts/header" %>
       <main id="content" role="main" class="content">


### PR DESCRIPTION
Added code for Google Tag Manager to application layout. This will only be included if the environment  variable `GTM_CODE` is present. This env var should contain the correct GTM code for the environment.