### PR TITLE
Fixed issue with extracting pre-2000 financial year dates

### DIFF
--- a/app/services/transaction_file_importer.rb
+++ b/app/services/transaction_file_importer.rb
@@ -192,9 +192,8 @@ class TransactionFileImporter
   end
 
   def determine_financial_year(date)
-    y = date.month < 4 ? date.year - 1 : date.year
-    y -= 2000 if y > 2000
-    sprintf('%02d%02d', y, y + 1)
+    y = (date.month < 4 ? date.year - 1 : date.year) % 100
+    sprintf('%02d%02d', y, (y + 1) % 100)
   end
 
   def sanitize_date(d)

--- a/db/migrate/20190408123824_fix_pre_2000_financial_year_dates.rb
+++ b/db/migrate/20190408123824_fix_pre_2000_financial_year_dates.rb
@@ -1,0 +1,14 @@
+class FixPre2000FinancialYearDates < ActiveRecord::Migration[5.1]
+  def up
+    importer = TransactionFileImporter.new
+    arel = TransactionDetail.arel_table
+    date = Date.parse('1-APR-2001')
+    TransactionDetail.where(arel[:period_start].lt(date)).each do |t|
+      t.tcm_financial_year = importer.determine_financial_year(t.period_start)
+      t.save!
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190221152034) do
+ActiveRecord::Schema.define(version: 20190408123824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/services/transaction_file_importer_test.rb
+++ b/test/services/transaction_file_importer_test.rb
@@ -104,4 +104,24 @@ class TransactionFileImporterTest < ActiveSupport::TestCase
     d = 'There is no Charge Code here, so none shall be returned'
     assert_nil @importer.extract_charge_code(d)
   end
+
+  def test_determine_financial_year_handles_2000_onwards_dates
+    [['10-JUL-2010', '1011'],
+     ['1-FEB-2019', '1819'],
+     ['22-MAR-2000', '9900'],
+     ['1-APR-2001', '0102']].each do |y|
+      d = Date.parse(y[0])
+      assert_equal y[1], @importer.determine_financial_year(d)
+     end
+  end
+
+  def test_determine_financial_year_handles_pre_2000_dates
+    [['10-JUL-1995', '9596'],
+     ['1-FEB-1997', '9697'],
+     ['22-MAR-1998', '9798'],
+     ['1-APR-1999', '9900']].each do |y|
+      d = Date.parse(y[0])
+      assert_equal y[1], @importer.determine_financial_year(d)
+     end
+  end
 end


### PR DESCRIPTION
When importing transactions the system extracts and examines the charging period for the transaction and then build a string value to represent the financial year e.g. `1819` for 2018-2019, which is stored in the `tcm_financial_year` attribute.  Pre-2000 dates were not being handled correctly, so this is a fix for that.  Also there is a migration included that fixes this attribute for any pre-2000 values that have already been imported.