### PR TITLE
Added user role to cache key for transactions

### DIFF
--- a/app/views/transactions/_cfd_table.html.erb
+++ b/app/views/transactions/_cfd_table.html.erb
@@ -31,7 +31,7 @@
   </thead>
   <tbody>
     <% view_model.present_paged_transactions.each do |transaction| %>
-      <% cache transaction do %>
+      <% cache [ current_user.role, transaction ] do %>
         <%= render partial: 'cfd_transaction',
           locals: { transaction: transaction,
                     data_path: regime_transaction_path(view_model.regime, transaction) } %>

--- a/app/views/transactions/_pas_table.html.erb
+++ b/app/views/transactions/_pas_table.html.erb
@@ -24,7 +24,7 @@
   </thead>
   <tbody>
     <% view_model.present_paged_transactions.each do |transaction| %>
-      <% cache transaction do %>
+      <% cache [ current_user.role, transaction ] do %>
         <%= render partial: 'pas_transaction',
           locals: { transaction: transaction,
                     data_path: regime_transaction_path(view_model.regime, transaction) } %>

--- a/app/views/transactions/_wml_table.html.erb
+++ b/app/views/transactions/_wml_table.html.erb
@@ -23,7 +23,7 @@
   </thead>
   <tbody>
     <% view_model.present_paged_transactions.each do |transaction| %>
-      <% cache transaction do %>
+      <% cache [ current_user.role, transaction ] do %>
         <%= render partial: 'wml_transaction',
           locals: { transaction: transaction,
                     data_path: regime_transaction_path(view_model.regime,


### PR DESCRIPTION
Fragment caching of the transaction detail rows in TTBB did not consider the user's role.
For instance a billing or admin role would see controls for changing category, temporary cessation and approval, but a read only user should not see those controls.
If the row was cached and included in the TTBB view for a user with a different role it could be incorrectly displayed for that user.
The fix is to add the user's role to the cache key for the transaction fragment, to try and keep the reuse of the cached row but safely across users with the same role.