### PR TITLE
Fixed logic to test for excluded transactions

### DIFF
--- a/app/presenters/transaction_header_presenter.rb
+++ b/app/presenters/transaction_header_presenter.rb
@@ -3,7 +3,7 @@ class TransactionHeaderPresenter < SimpleDelegator
 
   def can_be_removed?
     # TODO: can only be removed if no :transaction_details have been billed
-    !removed && billed_items.count.zero?
+    !removed && billed_items.count.zero? && excluded_items.count.zero?
   end
 
   def transactions


### PR DESCRIPTION
Logic to decide whether an imported transaction file can be deleted or not was not correctly checking that none of the transactions had been permanently excluded.