### PR TITLE
Added locale text for transaction header name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,9 @@
 en:
+  activerecord:
+    models:
+      transaction_header:
+        one: 'transaction file'
+        other: 'transaction files'
   user:
     roles:
       admin: 'System Admin'


### PR DESCRIPTION
In pagination, the model name is used to describe the entries being paginated. It makes it clearer to the end user if the `TransactionHeader` model is described as a __transaction file__ so entries for single and plural transaction files have been added to the locale file to support this.