### PR TITLE
Set default sort order to desc for imported transaction files

### DIFF
--- a/app/controllers/concerns/view_model_builder.rb
+++ b/app/controllers/concerns/view_model_builder.rb
@@ -10,7 +10,7 @@ module ViewModelBuilder
     vm.page = params.fetch(:page, 1)
     vm.per_page = params.fetch(:per_page, 10)
     vm.sort = params.fetch(:sort, :file_reference)
-    vm.sort_direction = params.fetch(:sort_direction, 'asc')
+    vm.sort_direction = params.fetch(:sort_direction, 'desc')
     vm.check_params
     vm
   end

--- a/app/services/query/imported_transaction_files.rb
+++ b/app/services/query/imported_transaction_files.rb
@@ -5,7 +5,7 @@ module Query
       @region = opts.fetch(:region, '')
       @status = opts.fetch(:status, '')
       @sort_column = opts.fetch(:sort, :file_reference)
-      @sort_direction = opts.fetch(:sort_direction, 'asc')
+      @sort_direction = opts.fetch(:sort_direction, 'desc')
       @search = opts.fetch(:search, '')
     end
 


### PR DESCRIPTION
When viewing imported transaction files, it makes more sense to have the latest file at the top of the list rather than the oldest so switch the default sort order to `:desc` instead of `:asc`