### PR TITLE
Changed default sort column for imported files view

### DIFF
--- a/app/controllers/concerns/view_model_builder.rb
+++ b/app/controllers/concerns/view_model_builder.rb
@@ -9,7 +9,7 @@ module ViewModelBuilder
     vm.search = params.fetch(:search, '')
     vm.page = params.fetch(:page, 1)
     vm.per_page = params.fetch(:per_page, 10)
-    vm.sort = params.fetch(:sort, :file_reference)
+    vm.sort = params.fetch(:sort, :created_at)
     vm.sort_direction = params.fetch(:sort_direction, 'desc')
     vm.check_params
     vm

--- a/app/models/view_models/imported_transaction_files.rb
+++ b/app/models/view_models/imported_transaction_files.rb
@@ -12,8 +12,8 @@ module ViewModels
       @status = params.fetch(:status, '')
       @page = 1
       @per_page = 10
-      @sort = 'file_reference'
-      @sort_direction = 'asc'
+      @sort = 'created_at'
+      @sort_direction = 'desc'
       @permit_all_regions = true
     end
 

--- a/app/services/query/imported_transaction_files.rb
+++ b/app/services/query/imported_transaction_files.rb
@@ -4,7 +4,7 @@ module Query
       @regime = opts.fetch(:regime)
       @region = opts.fetch(:region, '')
       @status = opts.fetch(:status, '')
-      @sort_column = opts.fetch(:sort, :file_reference)
+      @sort_column = opts.fetch(:sort, :created_at)
       @sort_direction = opts.fetch(:sort_direction, 'desc')
       @search = opts.fetch(:search, '')
     end
@@ -35,8 +35,8 @@ module Query
       case @sort_column.to_sym
       when :generated_at
         q.order(generated_at: dir, id: dir)
-      when :created_at
-        q.order(created_at: dir, id: dir)
+      when :file_reference
+        q.order(file_reference: dir, id: dir)
       when :credit_count
         q.order(credit_count: dir, id: dir)
       when :credit_total
@@ -44,7 +44,7 @@ module Query
       when :invoice_total
         q.order(invoice_total: dir, id: dir)
       else
-        q.order(file_reference: dir, id: dir)
+        q.order(created_at: dir, id: dir)
       end
     end
   end


### PR DESCRIPTION
Use the `:created_at` column as the default for __Imported Transaction Files__ view instead of `:file_reference` to order files by date imported into TCM