### PR TITLE
Populate file reference for TransactionHeader

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -129,3 +129,9 @@ TransactionFile.where(file_reference: nil).each do |f|
   f.file_reference = f.base_filename
   f.save!
 end
+
+# fix up TransactionHeader file references
+TransactionHeader.where(file_reference: nil).each do |th|
+  th.send :generate_file_reference
+  th.save!
+end


### PR DESCRIPTION
Populates the `:file_reference` field for TransactionHeader record in seeds file.