### PR TITLE
Changed message for multiple transaction mismatch

### DIFF
--- a/app/services/permits/category_processor_base.rb
+++ b/app/services/permits/category_processor_base.rb
@@ -93,6 +93,11 @@ module Permits
                       "Multiple matching transactions found in file", stage)
     end
 
+    def different_number_of_matching_transactions(where_args, stage)
+      make_suggestion(where_args, :red,
+                      "Number of matching transactions differs from number in file", stage)
+    end
+
     def set_logic_message(where_args, msg)
       unbilled_transactions(where_args) do |t|
         # FIXME: not using this now - only left until all

--- a/app/services/permits/pas_category_processor.rb
+++ b/app/services/permits/pas_category_processor.rb
@@ -165,7 +165,7 @@ module Permits
           end
         else
           header.transaction_details.invoices.where(query_args).each do |t|
-            multiple_historic_matches({ id: t.id }, stage)
+            different_number_of_matching_transactions({ id: t.id }, stage)
           end
         end
       end
@@ -252,7 +252,7 @@ module Permits
           end
         else
           header.transaction_details.credits.where(query_args).each do |t|
-            multiple_historic_matches({ id: t.id }, stage)
+            different_number_of_matching_transactions({ id: t.id }, stage)
           end
         end
       end

--- a/test/services/permits/pas_category_processor_test.rb
+++ b/test/services/permits/pas_category_processor_test.rb
@@ -1052,7 +1052,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
-      assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
+      assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary invoice (multiple) - Stage 2',
                    sc.suggestion_stage, 'Wrong stage')
     end
@@ -1228,7 +1228,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
-      assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
+      assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary invoice (multiple) - Stage 4',
                    sc.suggestion_stage, 'Wrong stage')
     end
@@ -1717,7 +1717,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
-      assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
+      assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 2',
                    sc.suggestion_stage, 'Wrong stage')
     end
@@ -1806,7 +1806,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
-      assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
+      assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 4',
                    sc.suggestion_stage, 'Wrong stage')
     end


### PR DESCRIPTION
When processing multiple matching transactions for category suggestion, add new message for the case when multiple historic matches have been found but there are more or less of them than in the file