### PR TITLE
All PAS credit assignments are locked (might need to change this)

### DIFF
--- a/app/services/permits/pas_category_processor.rb
+++ b/app/services/permits/pas_category_processor.rb
@@ -193,7 +193,7 @@ module Permits
         if invoices.count.zero?
           no_historic_transaction({ id: transaction.id }, stage)
         elsif invoices.count == 1
-          set_category(transaction, invoices.first, :green, stage)
+          set_category(transaction, invoices.first, :green, stage, true)
         else
           stage = if with_customer_reference
             "Supplementary credit (single) - Stage 2"
@@ -202,7 +202,7 @@ module Permits
           end
 
           if invoices.first.period_start != invoices.second.period_start
-            set_category(transaction, invoices.first, :amber, stage)
+            set_category(transaction, invoices.first, :amber, stage, true)
           else
             multiple_historic_matches({ id: transaction.id }, stage)
           end
@@ -230,7 +230,7 @@ module Permits
       elsif invoices.count == count
         cnt = 0
         header.transaction_details.credits.where(query_args).each do |t|
-          set_category(t, invoices[cnt], :amber, stage)
+          set_category(t, invoices[cnt], :amber, stage, true)
           cnt += 1
         end
       else
@@ -247,7 +247,7 @@ module Permits
         if invoices.count == count
           cnt = 0
           header.transaction_details.credits.where(query_args).each do |t|
-            set_category(t, invoices[cnt], :amber, stage)
+            set_category(t, invoices[cnt], :amber, stage, true)
             cnt += 1
           end
         else

--- a/test/services/permits/pas_category_processor_test.rb
+++ b/test/services/permits/pas_category_processor_test.rb
@@ -1268,6 +1268,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_equal('2.4.6', t.reload.category, 'Incorrect category set')
     sc = t.suggested_category
     assert(sc.green?, 'Not GREEN')
+    assert(sc.admin_lock?, 'Not locked')
     assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 1',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1306,6 +1307,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_equal('2.4.6', t.reload.category, 'Incorrect category set')
     sc = t.suggested_category
     assert(sc.amber?, 'Not AMBER')
+    assert(sc.admin_lock?, 'Not locked')
     assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 2',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1344,6 +1346,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_nil(t.reload.category, 'Category set')
     sc = t.suggested_category
     assert(sc.red?, 'Not RED')
+    refute(sc.admin_lock?, 'Is locked')
     assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 2',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1382,6 +1385,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_equal('2.4.6', t.reload.category, 'Incorrect category set')
     sc = t.suggested_category
     assert(sc.green?, 'Not GREEN')
+    assert(sc.admin_lock?, 'Not locked')
     assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 3',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1420,6 +1424,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_equal('2.4.6', t.reload.category, 'Incorrect category set')
     sc = t.suggested_category
     assert(sc.amber?, 'Not AMBER')
+    assert(sc.admin_lock?, 'Not locked')
     assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 4',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1458,6 +1463,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_nil(t.reload.category, 'Category set')
     sc = t.suggested_category
     assert(sc.red?, 'Not RED')
+    refute(sc.admin_lock?, 'Is locked')
     assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 4',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1496,6 +1502,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
     assert_nil(t.reload.category, 'Category set')
     sc = t.suggested_category
     assert(sc.red?, 'Not RED')
+    refute(sc.admin_lock?, 'Is locked')
     assert_equal('No previous bill found', sc.logic, 'Wrong outcome')
     assert_equal('Supplementary credit (single) - Stage 3',
                  sc.suggestion_stage, 'Wrong stage')
@@ -1540,6 +1547,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assigned << t.category
       sc = t.suggested_category
       assert(sc.amber?, 'Not AMBER')
+      assert(sc.admin_lock?, 'Not locked')
       assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 1',
                    sc.suggestion_stage, 'Wrong stage')
@@ -1586,6 +1594,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assigned << t.category
       sc = t.suggested_category
       assert(sc.amber?, 'Not AMBER')
+      assert(sc.admin_lock?, 'Not locked')
       assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 3',
                    sc.suggestion_stage, 'Wrong stage')
@@ -1628,6 +1637,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
+      refute(sc.admin_lock?, 'Is locked')
       assert_equal('No previous bill found', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 3',
                    sc.suggestion_stage, 'Wrong stage')
@@ -1674,6 +1684,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assigned << t.category
       sc = t.suggested_category
       assert(sc.amber?, 'Not AMBER')
+      assert(sc.admin_lock?, 'Not locked')
       assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 2',
                    sc.suggestion_stage, 'Wrong stage')
@@ -1718,6 +1729,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
       assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
+      refute(sc.admin_lock?, 'Is locked')
       assert_equal('Supplementary credit (multiple) - Stage 2',
                    sc.suggestion_stage, 'Wrong stage')
     end
@@ -1763,6 +1775,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assigned << t.category
       sc = t.suggested_category
       assert(sc.amber?, 'Not AMBER')
+      assert(sc.admin_lock?, 'Not locked')
       assert_equal('Assigned matching category', sc.logic, 'Wrong outcome')
       assert_equal('Supplementary credit (multiple) - Stage 4',
                    sc.suggestion_stage, 'Wrong stage')
@@ -1807,6 +1820,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
       assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
+      refute(sc.admin_lock?, 'Is locked')
       assert_equal('Supplementary credit (multiple) - Stage 4',
                    sc.suggestion_stage, 'Wrong stage')
     end


### PR DESCRIPTION
Ensure the admin lock is set after a category suggestion is made with either Green or Amber RAG status.