### PR TITLE
Changed message for PAS PCS annual billing mismatched numbers

### DIFF
--- a/app/services/permits/pas_category_processor.rb
+++ b/app/services/permits/pas_category_processor.rb
@@ -63,7 +63,7 @@ module Permits
       elsif historic_transactions.count.zero?
         no_historic_transaction(permit_args, stage)
       else
-        multiple_historic_matches(permit_args, stage)
+        different_number_of_matching_transactions(permit_args, stage)
       end
     end
 

--- a/test/services/permits/pas_category_processor_test.rb
+++ b/test/services/permits/pas_category_processor_test.rb
@@ -521,7 +521,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
-      assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
+      assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
       assert_equal('Annual billing (multiple) - Stage 1', sc.suggestion_stage,
                 'Wrong stage')
     end
@@ -610,7 +610,7 @@ class PasCategoryProcessorTest < ActiveSupport::TestCase
       assert_nil(t.reload.category, 'Category set')
       sc = t.suggested_category
       assert(sc.red?, 'Not RED')
-      assert_equal('Multiple historic matches found', sc.logic, 'Wrong outcome')
+      assert_equal('Number of matching transactions differs from number in file', sc.logic, 'Wrong outcome')
       assert_equal('Annual billing (multiple) - Stage 2', sc.suggestion_stage,
                 'Wrong stage')
     end


### PR DESCRIPTION
Changed outcome message from "Multiple historic matches found" to "Number of matching transactions differs from number in file" when multiple incoming annual billing transactions for a given permit do not match the same number of historic transactions for that permit during Permit category suggestion for Installations.