### PR TITLE
Update email config for development env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,10 +137,6 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
-    launchy (2.4.3)
-      addressable (~> 2.3)
-    letter_opener (1.6.0)
-      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -326,7 +322,6 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   kaminari
-  letter_opener
   listen (>= 3.0.5, < 3.2)
   memory_profiler
   minitest-reporters
@@ -357,4 +352,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,10 +16,6 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # show error pages
-  # config.consider_all_requests_local = false
-  # config.action_dispatch.show_exceptions = true
-
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
@@ -34,16 +30,31 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Sending e-mails is required for confirmation emails
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("DEFAULT_URL_HOST", "http://localhost:3000"),
+    protocol: "http"
+  }
+
+  # Don't care if the mailer can't send (if set to false)
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+
+  # Default settings are for mailcatcher
+  config.action_mailer.smtp_settings = {
+    user_name: ENV.fetch("EMAIL_USERNAME", ""),
+    password: ENV.fetch("EMAIL_PASSWORD", ""),
+    domain: ENV.fetch("DEFAULT_URL_HOST", "http://localhost:3000"),
+    address: ENV.fetch("EMAIL_HOST", "localhost"),
+    port: ENV.fetch("EMAIL_PORT", 1025),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter     = :resque
   config.active_job.queue_name_prefix = "sroc-tcm-admin_#{Rails.env}"
-
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  config.action_mailer.delivery_method = :letter_opener
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
The current configuration relies on [letter_opener](https://github.com/ryanb/letter_opener) to see emails when working in `development` mode.

That's fine if you are running the app directly on the host. But we also want to support the option to run the app in tools like [vagrant](https://www.vagrantup.com/) and [docker](https://www.docker.com/) where this no longer works.

So this updates the config to asume you have [Mailcatcher](https://mailcatcher.me/) running when working locally. This better represents production and gives us more flexibility on where we can run the app.

N.B. This config and approach is taken rom Waste Carriers, Waste Exemptions and Flood Risk Activity Exemptions which are also Rails based services.