### PR TITLE
Inc. logging in Capybara selenium driver config

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,9 +28,11 @@ Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w[ headless disable-gpu no-sandbox disable-dev-shm-usage window-size=1600,1000 ] }
   )
+  driver_options = { verbose: true, log_path: 'tmp/chromedriver.log' }
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 desired_capabilities: capabilities)
+                                 desired_capabilities: capabilities,
+                                 driver_opts: driver_options)
 end
 
 # Capybara.javascript_driver = :chrome


### PR DESCRIPTION
Whilst trying to add support for running the integration tests headlessly in our new Vagrant box for the service, we found it extremely useful to see the logs for chromedriver.

This makes the change permanently, so we can easliy access them should we have issues in the future.