### PR TITLE
Example API Connector implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,10 @@ gem 'devise_invitable'
 
 gem 'secure_headers'
 
+# Wrapper for the OAuth 2.0 specification (https://oauth.net/2/). Needed to
+# authenticate with the Charging Module API
+gem 'oauth2'
+
 group :production do
   gem 'airbrake', "~> 5.0"
 end
@@ -105,6 +109,8 @@ group :test do
   gem 'simplecov', require: false
   gem 'minitest-reporters'
   gem 'mocha'
+  # Stubbing HTTP requests
+  gem 'webmock'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     devise (4.7.2)
       bcrypt (~> 3.0)
@@ -111,10 +113,13 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
     flamegraph (0.9.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -127,6 +132,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.3.1)
+    jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -163,11 +169,19 @@ GEM
       metaclass (~> 0.0.1)
     mono_logger (1.1.0)
     multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
     orm_adapter (0.5.0)
     passenger (5.3.7)
       rack
@@ -251,6 +265,7 @@ GEM
     ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -315,6 +330,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -349,6 +368,7 @@ DEPENDENCIES
   memory_profiler
   minitest-reporters
   mocha
+  oauth2
   passenger (~> 5.1)
   pg (~> 0.18)
   puma (~> 3.7)
@@ -370,6 +390,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
   whenever
 
 RUBY VERSION

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -5,4 +5,12 @@ module Exceptions
   class TransactionFileError < StandardError; end
   class PermissionError < StandardError; end
   class CalculationServiceError < StandardError; end
+
+  class ChargingModuleApiError < StandardError
+    def initialize(http, endpoint, response)
+      super(
+        "Failed to connect to Charging Module API. Http = #{http}, endpoint = #{endpoint}, response = #{response}."
+      )
+    end
+  end
 end

--- a/app/services/charging_module/authorisation_service.rb
+++ b/app/services/charging_module/authorisation_service.rb
@@ -2,6 +2,7 @@
 
 module ChargingModule
   class AuthorisationService < ServiceObject
+
     attr_reader :token
 
     # The current design of the base service object requires us to provide an

--- a/app/services/charging_module/authorisation_service.rb
+++ b/app/services/charging_module/authorisation_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ChargingModule
+  class AuthorisationService < ServiceObject
+    attr_reader :token
+
+    # The current design of the base service object requires us to provide an
+    # initialise method even if we don't need it
+    def initialize(_params = {}); end
+
+    def call
+      @result = true
+      @token = oauth2_token
+      self
+    rescue StandardError
+      @result = false
+      raise
+    end
+
+    private
+
+    def host
+      @host ||= ENV.fetch("COGNITO_HOST")
+    end
+
+    def username
+      @username ||= ENV.fetch("COGNITO_USERNAME")
+    end
+
+    def password
+      @password ||= ENV.fetch("COGNITO_PASSWORD")
+    end
+
+    def oauth2_token
+      OAuth2::Client.new(username, password, site: host, token_url: "/oauth2/token")
+                    .client_credentials
+                    .get_token.token
+    end
+  end
+end

--- a/app/services/charging_module/concerns/can_connect_to_api.rb
+++ b/app/services/charging_module/concerns/can_connect_to_api.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module ChargingModule
+  module CanConnectToApi
+    extend ActiveSupport::Concern
+
+    private
+
+    def make_get_request(endpoint)
+      make_request(Net::HTTP::Get, endpoint, nil)
+    end
+
+    def make_request(http, endpoint, payload)
+      request = build_http_request(endpoint, payload, http)
+      response = send_request(request)
+      handle_request_response(endpoint, http, response)
+    end
+
+    def build_http_request(endpoint, payload, http)
+      request = http.new(
+        "#{url}/#{endpoint}",
+        'Content-Type': 'application/json',
+        'Authorization': auth_token
+      )
+      request.body = payload.to_json unless payload.present?
+
+      request
+    end
+
+    def send_request(request)
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = url.scheme.downcase == 'https'
+
+      http.request(request)
+    end
+
+    def handle_request_response(endpoint, http, response)
+      return successful_request(response.body) if response.code == "200"
+
+      raise Exceptions::ChargingModuleApiError.new(http, endpoint, response)
+    end
+
+    def successful_request(body)
+      JSON.parse(body, symbolize_names: true)
+    end
+
+    def url
+      @url ||= URI.parse(ENV.fetch('CHARGING_MODULE_API'))
+    end
+
+    def auth_token
+      @auth_token ||= AuthorisationService.call.token
+    end
+  end
+end

--- a/app/services/charging_module/list_bill_runs_service.rb
+++ b/app/services/charging_module/list_bill_runs_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "concerns/can_connect_to_api"
+
+module ChargingModule
+  class ListBillRunsService < ServiceObject
+    include ChargingModule::CanConnectToApi
+
+    attr_reader :response
+
+    def initialize(params = {})
+      regime = params.fetch(:regime)
+      @endpoint = "#{regime}/billruns"
+    end
+
+    def call
+      @response = make_get_request(@endpoint)
+      @result = true
+
+      self
+    rescue StandardError => e
+      @result = false
+      TcmLogger.notify(e)
+
+      self
+    end
+  end
+end

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,6 +1,0 @@
-example_id                                         | status | run_time        |
--------------------------------------------------- | ------ | --------------- |
-./spec/helpers/application_helper_spec.rb[1:1:1:1] | passed | 0.00122 seconds |
-./spec/helpers/application_helper_spec.rb[1:1:2:1] | passed | 0.00121 seconds |
-./spec/helpers/application_helper_spec.rb[1:1:3:1] | passed | 0.02191 seconds |
-./spec/helpers/application_helper_spec.rb[1:1:4:1] | passed | 0.00181 seconds |

--- a/spec/fixtures/charging_module/list_bill_runs_success.json
+++ b/spec/fixtures/charging_module/list_bill_runs_success.json
@@ -1,0 +1,18 @@
+{
+  "bills": [
+    {
+      "_id": "5f3e4d45c4d01f0199d28ab0",
+      "index": 0,
+      "status": "calculating",
+      "balance": "1,691.34",
+      "created": "2014-01-26T06:03:26 -00:00"
+    },
+    {
+      "_id": "5f3e4d453b41a262a1023df8",
+      "index": 1,
+      "status": "calculating",
+      "balance": "1,173.92",
+      "created": "2014-05-07T12:52:37 -01:00"
+    }
+  ]
+}

--- a/spec/fixtures/charging_module/list_bill_runs_success.json
+++ b/spec/fixtures/charging_module/list_bill_runs_success.json
@@ -1,18 +1,54 @@
 {
-  "bills": [
-    {
-      "_id": "5f3e4d45c4d01f0199d28ab0",
-      "index": 0,
-      "status": "calculating",
-      "balance": "1,691.34",
-      "created": "2014-01-26T06:03:26 -00:00"
-    },
-    {
-      "_id": "5f3e4d453b41a262a1023df8",
-      "index": 1,
-      "status": "calculating",
-      "balance": "1,173.92",
-      "created": "2014-05-07T12:52:37 -01:00"
-    }
-  ]
+  "pagination": {
+      "page": 1,
+      "perPage": 50,
+      "pageCount": 1,
+      "recordCount": 2
+  },
+  "data": {
+      "billRuns": [
+          {
+              "id": "adb3d105-43ae-4cdd-9421-d18b1d32e484",
+              "region": "A",
+              "billRunNumber": 10002,
+              "fileId": 50001,
+              "transactionFileReference": "nalai50001.dat",
+              "transactionFileDate": null,
+              "status": "billed",
+              "approvedForBilling": false,
+              "preSroc": true,
+              "creditCount": 8,
+              "creditValue": -3928,
+              "invoiceCount": 48,
+              "invoiceValue": 1017868,
+              "creditLineCount": 8,
+              "creditLineValue": -3928,
+              "debitLineCount": 58,
+              "debitLineValue": 1017868,
+              "zeroValueLineCount": 0,
+              "netTotal": 1013940
+          },
+          {
+              "id": "27deb988-469f-4a88-ae65-6b32f925523d",
+              "region": "E",
+              "billRunNumber": 10001,
+              "fileId": 50001,
+              "transactionFileReference": "nalei50001.dat",
+              "transactionFileDate": null,
+              "status": "billed",
+              "approvedForBilling": true,
+              "preSroc": true,
+              "creditCount": 0,
+              "creditValue": 0,
+              "invoiceCount": 1,
+              "invoiceValue": 1386326,
+              "creditLineCount": 0,
+              "creditLineValue": 0,
+              "debitLineCount": 2,
+              "debitLineValue": 1386326,
+              "zeroValueLineCount": 0,
+              "netTotal": 1386326
+          }
+      ]
+  }
 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
+
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
-
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'

--- a/spec/services/charging_module/authorisation_service_spec.rb
+++ b/spec/services/charging_module/authorisation_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ChargingModule
+  RSpec.describe AuthorisationService do
+    before(:each) do
+      allow(ENV).to receive(:fetch).with('COGNITO_HOST')
+                                   .and_return('http://example.com')
+      allow(ENV).to receive(:fetch).with('COGNITO_USERNAME')
+                                   .and_return('auser')
+      allow(ENV).to receive(:fetch).with('COGNITO_PASSWORD')
+                                   .and_return('password12345')
+
+      allow(OAuth2::Client).to receive(:new)
+        .with("auser", "password12345", site: "http://example.com", token_url: "/oauth2/token")
+        .and_return(oauth2_client)
+    end
+
+    let(:oauth2_client) { double("OAuth2::Client", client_credentials: client_credentials) }
+    let(:client_credentials) { double("OAuth2::Strategy::ClientCredentials", get_token: access_token) }
+    let(:access_token) { double("OAuth2::AccessToken", token: token) }
+    let(:token) { "abcde12345" }
+
+    context "when everything is valid" do
+      it "returns a token" do
+        auth_service = described_class.call
+
+        expect(auth_service.token).to eq(token)
+      end
+
+      it "is successful" do
+        auth_service = described_class.call
+
+        expect(auth_service.success?).to be true
+      end
+    end
+
+    context "when authorisation fails" do
+      context "because the credentials are wrong" do
+        before do
+          stub_const("OAuth2::Error", StandardError)
+          allow(client_credentials).to receive(:get_token).and_raise(OAuth2::Error)
+        end
+
+        it "raises an error" do
+          expect { described_class.call }.to raise_error(OAuth2::Error)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/charging_module/list_bill_runs_service_spec.rb
+++ b/spec/services/charging_module/list_bill_runs_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ChargingModule
+  RSpec.describe ListBillRunsService do
+    before(:each) do
+      allow(ENV).to receive(:fetch).with('CHARGING_MODULE_API')
+                                   .and_return('http://localhost:3002/')
+
+      allow(AuthorisationService).to receive(:call).and_return(authorisation_service)
+
+      stub_request(:get, "http://localhost:3002//test/billruns")
+        .with(
+          body: "null",
+          headers: {
+            "Accept" => '*/*',
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => token,
+            "Content-Type" => "application/json",
+            "User-Agent" => "Ruby"
+          }
+        )
+        .to_return(status: code, body: body, headers: {})
+    end
+
+    let(:token) { "abcde12345" }
+    let(:authorisation_service) { double("AuthorisationService", token: token) }
+    let(:regime) { "test" }
+    let(:url) { "http://localhost:3002/v1/#{regime}" }
+
+    context "when the request is valid" do
+      let(:code) { 200 }
+      let(:body) { File.read("spec/fixtures/charging_module/list_bill_runs_success.json") }
+
+      it "returns a successful response" do
+        result = described_class.call(regime: regime)
+
+        expect(a_request(:get, url)).to have_been_made.at_most_once
+
+        expect(result.success?).to be true
+        expect(result.failed?).to be false
+        expect(result.response).to eq(JSON.parse(body, symbolize_names: true))
+      end
+    end
+
+    context "when the request fails" do
+      let(:code) { 500 }
+      let(:body) { nil }
+
+      it "returns a failed response" do
+        result = described_class.call(regime: regime)
+
+        expect(a_request(:get, url)).to have_been_made.at_most_once
+
+        expect(result.success?).to be false
+        expect(result.failed?).to be true
+        expect(result.response).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Stubbing HTTP requests
+require "webmock/rspec"


### PR DESCRIPTION
https://github.com/DEFRA/sroc-tcm-admin/pull/192

This is an example of how the work in PR #192 could be reworked to use modules. Our blocker was testing, and the fact we only really knew how to go about it using rspec. So we needed [RSpec integrated first](https://github.com/DEFRA/sroc-tcm-admin/pull/267) before we could tackle this example.