### PR TITLE
Fix flaky tests

### DIFF
--- a/test/integration/region_selector_test.rb
+++ b/test/integration/region_selector_test.rb
@@ -64,6 +64,7 @@ class RegionSelectorTest < ActionDispatch::IntegrationTest
     # select a region
     @regions_only.each do |r|
       page.select(r, from: 'region')
+      wait_for_ajax
       row_count = @regime.transaction_details.region(r).retrospective.count
       page.find(".tcm-table") do |t|
         # does region select have correct region selected?
@@ -101,6 +102,7 @@ class RegionSelectorTest < ActionDispatch::IntegrationTest
     # select a region
     @regions_only.each do |r|
       page.select(r, from: 'region')
+      wait_for_ajax
       row_count = @regime.transaction_details.region(r).historic_excluded.count
       page.find(".tcm-table") do |t|
         # does region select have correct region selected?
@@ -114,6 +116,7 @@ class RegionSelectorTest < ActionDispatch::IntegrationTest
 
     # select all regions
     page.select('All', from: 'region')
+    wait_for_ajax
     row_count = @regime.transaction_details.historic_excluded.count
     page.find(".tcm-table") do |t|
       # does region select have 'All' selected?

--- a/test/presenters/cfd_transaction_file_presenter_test.rb
+++ b/test/presenters/cfd_transaction_file_presenter_test.rb
@@ -4,6 +4,9 @@ class CfdTransactionFilePresenterTest < ActiveSupport::TestCase
   include TransactionFileFormat
 
   def setup
+    @user = users(:billing_admin)
+    Thread.current[:current_user] = @user
+
     @transaction_1 = transaction_details(:cfd)
     @transaction_2 = @transaction_1.dup
 


### PR DESCRIPTION
As noted in https://github.com/DEFRA/sroc-service-team/issues/7 several automated tests in `test/integration/region_selector_test.rb` were often (but not always) failing. This turned out to be because they needed to wait for the page to update after selecting a region -- fixed by using `wait_for_ajax` helper function (already used in some of the tests but not all for some reason).

One other test error we found https://github.com/DEFRA/sroc-service-team/issues/7#issuecomment-690957204 isn't fixed by this change, however it occurs very infrequently whereas the errors fixed here were happening almost every time the tests were run -- this at least fixes the most persistent errors so we can have much more confidence in the tests.