### PR TITLE
Update seed script to create test users

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,33 @@
+def create_user(details)
+  user = User.new(
+    first_name: details['firstname'],
+    last_name: details['lastname'],
+    email: details['email'],
+    role: details['role'],
+    password: ENV['DEFAULT_PASSWORD']
+  )
+
+  add_regimes_to_user(user, details['regimes']) if user.regime_users.empty?
+
+  user.save!
+end
+
+def add_regimes_to_user(user, regimes)
+  regimes.each do |name|
+    regime = Regime.find_by(name: name)
+    user.regime_users.build(regime_id: regime.id, enabled: true)
+  end
+end
+
+def seed_users
+  seeds = JSON.parse(File.read("#{Rails.root}/db/seeds/users.json"))
+  users = seeds['users']
+
+  users.each do |user|
+    create_user(user) unless User.where(email: user['email']).exists?
+  end
+end
+
 if Regime.count.zero?
   Regime.create!(name: 'PAS', title: 'Installations')
   Regime.create!(name: 'CFD', title: 'Water Quality')
@@ -11,25 +41,7 @@ Regime.all.each do |r|
   end
 end
 
-if User.count.zero?
-  u = User.new(first_name: 'System',
-               last_name: 'Account',
-               email: 'system@example.com',
-               role: 'admin',
-               password: "Ab0#{Devise.friendly_token.first(8)}")
-  u.regime_users.build(regime_id: Regime.first.id, enabled: true)
-  u.save!
-end
-
-unless User.where(email: 'stu@silverka.co.uk').exists?
-  u = User.new(first_name: 'Stuart',
-               last_name: 'Adair',
-               email: 'stu@silverka.co.uk',
-               role: 'admin',
-               password: "Ab0#{Devise.friendly_token.first(8)}")
-  u.regime_users.build(regime_id: Regime.first.id, enabled: true)
-  u.save!
-end
+seed_users
 
 r = Regime.find_by!(slug: 'pas')
 r.permit_categories.destroy_all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ def create_user(details)
     password: ENV['DEFAULT_PASSWORD']
   )
 
-  add_regimes_to_user(user, details['regimes']) if user.regime_users.empty?
+  add_regimes_to_user(user, details['regimes'])
 
   user.save!
 end

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -1,0 +1,60 @@
+{
+  "users" : [
+    {
+      "email": "system@example.com",
+      "role": "admin",
+      "firstname": "System",
+      "lastname": "Account",
+      "regimes": ["PAS"]
+    },
+    {
+      "email": "installations@sroc.gov.uk",
+      "role": "billing",
+      "firstname": "Installations",
+      "lastname": "User",
+      "regimes": ["PAS"]
+    },
+    {
+      "email" : "waste@sroc.gov.uk",
+      "role" : "billing",
+      "firstname": "Waste",
+      "lastname": "User",
+      "regimes": ["WML"]
+    },
+    {
+      "email" : "water@sroc.gov.uk",
+      "role" : "billing",
+      "firstname": "Water",
+      "lastname": "User",
+      "regimes": ["CFD"]
+    },
+    {
+      "email" : "admin@sroc.gov.uk",
+      "role" : "admin",
+      "firstname": "Admin",
+      "lastname": "User",
+      "regimes": ["CFD", "PAS", "WML"]
+    },
+    {
+      "email" : "billing@sroc.gov.uk",
+      "role" : "billing",
+      "firstname": "Billing",
+      "lastname": "User",
+      "regimes": ["CFD", "PAS", "WML"]
+    },
+    {
+      "email" : "export@sroc.gov.uk",
+      "role" : "read_only_export",
+      "firstname": "Export",
+      "lastname": "User",
+      "regimes": ["CFD", "PAS", "WML"]
+    },
+    {
+      "email" : "readonly@sroc.gov.uk",
+      "role" : "read_only",
+      "firstname": "Readonly",
+      "lastname": "User",
+      "regimes": ["CFD", "PAS", "WML"]
+    }
+  ]
+}

--- a/dotenv.example
+++ b/dotenv.example
@@ -5,3 +5,6 @@ REDIS_URL="localhost:6379"
 FILE_UPLOAD_ACCESS_KEY="aws_access_key_here"
 FILE_UPLOAD_SECRET_KEY="aws_secret_key_here"
 FILE_UPLOAD_BUCKET="aws_s3_bucket_url_here"
+
+# Used for seeding test accounts
+DEFAULT_PASSWORD=TestDefaultPassword1


### PR DESCRIPTION
We currently have an issue with the seeding of user accounts. We rely on a real email account to be used because we generate an unknownable password as part of the seeding. We need a real account so we can then the password reset mechanism to actually gain access.

This means if you were to seed a fresh environment, you could never actually use the `system@example.com` user unless you were able to intercept the email (only possible locally). The current seed design also makes it hard to write automated acceptance tests as we ideally need known users to authenticate with.

So the primary purpose for this change is to start seeding known user accounts based on roles and regimes. All will use the same known password taken from an environment variable.