### PR TITLE
Upgrade Airbrake to fix asset complile error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "whenever", require: false
 gem "turbolinks", "~> 5"
 
 group :production do
-  gem "airbrake", "~> 5.0"
+  gem "airbrake", "~> 11.0"
   # Use passenger as the app server in production. The environment web-ops have
   # built currently expects this to be the case
   gem "passenger", "~> 5.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,9 +58,10 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrake (5.8.1)
-      airbrake-ruby (~> 1.8)
-    airbrake-ruby (1.8.0)
+    airbrake (11.0.1)
+      airbrake-ruby (~> 5.1)
+    airbrake-ruby (5.2.0)
+      rbtree3 (~> 0.5)
     ast (2.4.1)
     autoprefixer-rails (10.0.1.2)
       execjs
@@ -249,6 +250,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbtree3 (0.6.0)
     redis (3.3.5)
     redis-namespace (1.8.0)
       redis (>= 3.0.4)
@@ -377,7 +379,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 5.0)
+  airbrake (~> 11.0)
   aws-sdk (~> 2)
   benchmark-ips
   bootstrap (~> 4.3.1)


### PR DESCRIPTION
https://trello.com/c/gKnSb5XO

When attempting to run the rake task which pre-compiles the assets we face this error

```
03:33 deploy:assets:precompile
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake assets:precompile
      01 rake aborted!
      01 NameError: uninitialized constant ActiveRecord::ConnectionAdapters::ConnectionManagement
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/airbrake-5.8.1/lib/airbrake/rails/railtie.rb:26:in `block in <class:Railtie>'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/initializable.rb:32:in `instance_exec'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/initializable.rb:32:in `run'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/initializable.rb:61:in `block in run_initializers'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/initializable.rb:60:in `run_initializers'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/application.rb:363:in `initialize!'
      01 /srv/ruby/tactical-charging-model/releases/20210106142545/config/environment.rb:7:in `<top (required)>'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/application.rb:339:in `require_environment!'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/railties-6.0.3.4/lib/rails/application.rb:523:in `block in run_tasks_blocks'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/airbrake-5.8.1/lib/airbrake/rake/task_ext.rb:19:in `execute'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/sprockets-rails-3.2.2/lib/sprockets/rails/task.rb:61:in `block (2 levels) in define'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/airbrake-5.8.1/lib/airbrake/rake/task_ext.rb:19:in `execute'
      01 /srv/ruby/tactical-charging-model/shared/bundle/ruby/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
      01 /home/ubuntu/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
      01 /home/ubuntu/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
      01 Tasks: TOP => environment
      01 (See full trace by running task with --trace)
```

A check in the interwebs points to the problem being an [outdated Airbrake dependency](https://stackoverflow.com/a/57880904/6117745). So this chage updates the airbrake gem dependency in the hopes of resolving the issue.