### PR TITLE
Fix database config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,26 +1,22 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV["POSTGRES_USERNAME"] %>
-  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV["RAILS_MAX_THREADS"] || 5 %>
+  host: <%= ENV["POSTGRES_HOST"] || "localhost" %>
+  port: <%= ENV["POSTGRES_PORT"] || 5432 %>
+  username: <%= ENV["POSTGRES_USERNAME"] || "vagrant" %>
+  password: <%= ENV["POSTGRES_PASSWORD"] || "vagrant" %>
 
 development:
   <<: *default
-  host: <%= ENV["POSTGRES_HOST"] %>
-  port: <%= ENV["POSTGRES_PORT"] %>
-  database: sroc
-  # database: sroc-tcm-admin_development
+  database: <%= ENV["POSTGRES_DB"] || "sroc-tcm-admin" %>
 
-test: &test
+test:
   <<: *default
-  host: <%= ENV["POSTGRES_HOST"] %>
-  post: <%= ENV["POSTGRES_PORT"] %>
-  database: sroc-tcm-admin_test
+  database: <%= ENV["POSTGRES_DB_TEST"] || "sroc-tcm-admin_test" %>
 
 production:
   <<: *default
-  database: sroc-tcm-admin_production
-
-cucumber:
-  <<: *test
+  database: <%= ENV["POSTGRES_DB"] || "sroc" %>


### PR DESCRIPTION
https://trello.com/c/gKnSb5XO

We've been struggling to get the application running in our AWS `DEVELOPMENT` environment since we started to make the updates for Ruby and Rails latest versions.

A lot of the confusion is coming from a mismatch between what env vars we see the code expects to find versus what is actually in the environments. It's one of the reasons we are trying to take more ownership.

This change deals with our current scenario. The `database.yml` is hard coding the name of the DB in production. But we can see previous deployments used a version where this could be overridden. The confusion is we can't see it in the commit history.

🤦😩 Urgh!

These changes resolve the issue with the config and should get us up and running finally!