### PR TITLE
Refactor how we get the current commit

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,13 +81,20 @@ module ApplicationHelper
     v
   end
 
-  def app_version_info
-    if File.exist? Rails.root.join("APPVERSION")
-      File.read(Rails.root.join("APPVERSION")).chomp
-    elsif File.exist? Rails.root.join("REVISION")
-      File.read(Rails.root.join("REVISION")).chomp
+  def current_git_commit
+    @current_git_commit ||= begin
+      sha =
+        if Rails.env.production?
+          capistrano_file = Rails.root.join "REVISION"
+
+          if File.exist? capistrano_file
+            File.open(capistrano_file, &:gets)
+          end
+        else
+          `git rev-parse HEAD`
+        end
+
+      sha[0...7] if sha.present?
     end
-  rescue StandardError => e
-    TcmLogger.notify(e)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,9 +87,7 @@ module ApplicationHelper
         if Rails.env.production?
           capistrano_file = Rails.root.join "REVISION"
 
-          if File.exist? capistrano_file
-            File.open(capistrano_file, &:gets)
-          end
+          File.open(capistrano_file, &:gets) if File.exist? capistrano_file
         else
           `git rev-parse HEAD`
         end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer id="footer" class="row footer">
   <div class="col">
-    <p class="app-version" aria-hidden="true">TCM Version: <%= app_version_info %></p>
+    <p class="app-version" aria-hidden="true">TCM Version: <%= current_git_commit %></p>
   </div>
 </footer>


### PR DESCRIPTION
We show the current Git commit in the footer of each page. It's a handy way of confirming which version of the application is running when you are trying to investigate issues.

Currently, the functionality relies on a task being run during the deployment to generate a file which contains the current commit hash. But we know from working on other projects that also provide a similar feature, Capistrano generates the same kind of file when it deploys the app.

So this change updates the project to use the same logic as services like Waste Carriers and Waste Exemptions. This also allows us to delete unnecessary functionality from the deployment job.