### PR TITLE
Remove redundant check rails rake task

### DIFF
--- a/lib/tasks/tcm.rake
+++ b/lib/tasks/tcm.rake
@@ -6,29 +6,6 @@ namespace :tcm do
     TransactionHeader.destroy_all
   end
 
-  desc "Check process running"
-  task check_rails_running: :environment do
-    path = Rails.root.join("tmp", "pids", "server.pid")
-    rails_running = true
-    if File.exist? path
-      pid = File.read(path).to_i
-      begin
-        Process.getpgid pid
-      rescue Errno::ESRCH
-        rails_running = false
-      end
-    else
-      rails_running = false
-      pid = "???"
-    end
-
-    if rails_running
-      puts "Rails running (pid: #{pid})"
-    else
-      abort("Cannot find rails process (pid: #{pid})")
-    end
-  end
-
   desc "Check charging service accessible"
   task check_charge_service: :environment do
     result = CalculationService.new.check_connectivity


### PR DESCRIPTION
Whilst migrating some existing Jenkins jobs to Jenkins pipelines we came across one intended to check that the app is up and running (it doesn't work!)

Whilst doing this we also came across `tcm:check_rails_running` within the app itself. This will only work locally because when the app is deployed in an AWS environment using Capistrano the PID files go into a shared directory.

We should add, we can also just make a request ourselves to confirm.

So this change removes the redundant, non-working rake task.