### PR TITLE
Update the project to use PostgreSQL v12.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:9.5-alpine
+        image: postgres:12.5-alpine
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres


### PR DESCRIPTION
Allow not clear from our current README the project is currently using version 9.5 of PostgreSQL. We will soon be updating our live environment to use PostgreSQL v12.5. This change mainly focuses on updating the CI workflow to ensure we are using v12.5.