### PR TITLE
Remove dependence on mimemagic gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,13 +7,13 @@ ruby "2.7.1"
 # RubyGems. See https://github.com/rails/rails/issues/41750
 # Referencing the rails dependencies directly was inspired by
 # https://github.com/DFE-Digital/early-careers-framework/pull/178
-#gem "rails", "~> 6.0.3"
+# gem "rails", "~> 6.0.3"
 # These rails gems need to be commented out to avoid bringing mimemagic in
 # activestorage is the gem that has a dependency on marcel, which has the dependency on mimemagic
-#gem "activestorage", "~> 6.0.3"
+# gem "activestorage", "~> 6.0.3"
 # actionmailbox and actiontext both have a dependency on activestorage
-#gem "actionmailbox", "~> 6.0.3"
-#gem "actiontext", "~> 6.0.3"
+# gem "actionmailbox", "~> 6.0.3"
+# gem "actiontext", "~> 6.0.3"
 gem "actioncable", "~> 6.0.3"
 gem "actionmailer", "~> 6.0.3"
 gem "actionpack", "~> 6.0.3"

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,29 @@
 source "https://rubygems.org"
 ruby "2.7.1"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", "~> 6.0.3"
+# Temporarily commented out due to the issue caused by mimemagic, a dependency of activestorage being yanked from
+# RubyGems. See https://github.com/rails/rails/issues/41750
+# Referencing the rails dependencies directly was inspired by
+# https://github.com/DFE-Digital/early-careers-framework/pull/178
+#gem "rails", "~> 6.0.3"
+# These rails gems need to be commented out to avoid bringing mimemagic in
+# activestorage is the gem that has a dependency on marcel, which has the dependency on mimemagic
+#gem "activestorage", "~> 6.0.3"
+# actionmailbox and actiontext both have a dependency on activestorage
+#gem "actionmailbox", "~> 6.0.3"
+#gem "actiontext", "~> 6.0.3"
+gem "actioncable", "~> 6.0.3"
+gem "actionmailer", "~> 6.0.3"
+gem "actionpack", "~> 6.0.3"
+gem "actionview", "~> 6.0.3"
+gem "activejob", "~> 6.0.3"
+gem "activemodel", "~> 6.0.3"
+gem "activerecord", "~> 6.0.3"
+gem "activesupport", "~> 6.0.3"
+gem "bundler", ">= 1.3.0"
+gem "railties", "~> 6.0.3"
+gem "sprockets-rails", ">= 2.0.0"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 0.18"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,13 +5,6 @@ GEM
       actionpack (= 6.0.3.5)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (6.0.3.5)
-      actionpack (= 6.0.3.5)
-      activejob (= 6.0.3.5)
-      activerecord (= 6.0.3.5)
-      activestorage (= 6.0.3.5)
-      activesupport (= 6.0.3.5)
-      mail (>= 2.7.1)
     actionmailer (6.0.3.5)
       actionpack (= 6.0.3.5)
       actionview (= 6.0.3.5)
@@ -25,12 +18,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (6.0.3.5)
-      actionpack (= 6.0.3.5)
-      activerecord (= 6.0.3.5)
-      activestorage (= 6.0.3.5)
-      activesupport (= 6.0.3.5)
-      nokogiri (>= 1.8.5)
     actionview (6.0.3.5)
       activesupport (= 6.0.3.5)
       builder (~> 3.1)
@@ -45,11 +32,6 @@ GEM
     activerecord (6.0.3.5)
       activemodel (= 6.0.3.5)
       activesupport (= 6.0.3.5)
-    activestorage (6.0.3.5)
-      actionpack (= 6.0.3.5)
-      activejob (= 6.0.3.5)
-      activerecord (= 6.0.3.5)
-      marcel (~> 0.3.1)
     activesupport (6.0.3.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -170,11 +152,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (0.3.3)
-      mimemagic (~> 0.3.2)
     memory_profiler (1.0.0)
     method_source (1.0.0)
-    mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -215,21 +194,6 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.0.3.5)
-      actioncable (= 6.0.3.5)
-      actionmailbox (= 6.0.3.5)
-      actionmailer (= 6.0.3.5)
-      actionpack (= 6.0.3.5)
-      actiontext (= 6.0.3.5)
-      actionview (= 6.0.3.5)
-      activejob (= 6.0.3.5)
-      activemodel (= 6.0.3.5)
-      activerecord (= 6.0.3.5)
-      activestorage (= 6.0.3.5)
-      activesupport (= 6.0.3.5)
-      bundler (>= 1.3.0)
-      railties (= 6.0.3.5)
-      sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -382,11 +346,20 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actioncable (~> 6.0.3)
+  actionmailer (~> 6.0.3)
+  actionpack (~> 6.0.3)
+  actionview (~> 6.0.3)
+  activejob (~> 6.0.3)
+  activemodel (~> 6.0.3)
+  activerecord (~> 6.0.3)
+  activesupport (~> 6.0.3)
   airbrake (~> 11.0)
   aws-sdk (~> 2)
   benchmark-ips
   bootstrap (~> 4.3.1)
   bstard
+  bundler (>= 1.3.0)
   byebug
   capybara
   capybara-selenium
@@ -408,9 +381,9 @@ DEPENDENCIES
   pg (~> 0.18)
   puma
   rack-mini-profiler
-  rails (~> 6.0.3)
   rails-controller-testing
   rails-i18n
+  railties (~> 6.0.3)
   redis (~> 3.2)
   resque
   rspec-rails
@@ -420,6 +393,7 @@ DEPENDENCIES
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets-rails (>= 2.0.0)
   stackprof
   turbolinks (~> 5)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
First, scan [Dependency on mimemagic 0.3.x no longer valid](https://github.com/rails/rails/issues/41750) for context!

In summary, **Rails** depends on **activestorage** which depends on **marcel** which depends on **mimemagic**. Yesterday, the author of **mimemagic** was informed it was in violation of the [GPL license](https://choosealicense.com/licenses/gpl-3.0/). So, they chose to

- yank all versions up to and including 0.3.5 from rubygems
- release a new version under the GPL
- archive the project for all further changes/issues/pr's etc

Via the dependency chain **Rails** relies on **mimemagic 0.3.5** so new installs of **Rails** are now broken. It also can't just pull in the new version due to the clash with the GPL license.

Efforts are afoot to resolve the issue.

- A [fork of mimemagic](https://github.com/jellybob/mimemagic) which relies on the GPL source data being already installed and read at run time
- Updating **marcel** to use [MiniMime](https://github.com/rails/marcel/pull/25) and [ruby-magic](https://github.com/rails/marcel/pull/26) instead of **mimemagic**

Till the community has settled on a solution though, we need a fix in the short term. Ours is based on

- What the Dept. for Education team have done in [early-careers-framework](https://github.com/DFE-Digital/early-careers-framework/pull/178)
- What Sentry are doing [in their app](https://github.com/getsentry/sentry-ruby/issues/1362)

Instead of referencing `rails` in the `Gemfile` they are referencing just the parts needed and excluding `activestorage` and anything with a dependency on it.

This change does exactly the same thing.