### PR TITLE
Fix broken download transaction data link

### DIFF
--- a/app/controllers/annual_billing_data_files_controller.rb
+++ b/app/controllers/annual_billing_data_files_controller.rb
@@ -93,7 +93,7 @@ class AnnualBillingDataFilesController < ApplicationController
   def present_file(upload, errors)
     {
       filename: File.basename(upload.filename),
-      upload_date: helpers.formatted_date(upload.created_at, true),
+      upload_date: helpers.formatted_date(upload.created_at, include_time: true),
       status: upload.status.humanize,
       success_count: upload.success_count,
       failed_count: upload.failed_count,

--- a/app/views/annual_billing_data_files/_upload_details.html.erb
+++ b/app/views/annual_billing_data_files/_upload_details.html.erb
@@ -2,7 +2,7 @@
   <dt class="col-sm-4 col-md-3">Filename</dt>
   <dd class="col-sm-7 col-md-8"><%= File.basename @upload.filename %></dd>
   <dt class="col-sm-4 col-md-3">Date uploaded</dt>
-  <dd class="col-sm-7 col-md-8"><%= formatted_date(@upload.created_at, true) %></dd>
+  <dd class="col-sm-7 col-md-8"><%= formatted_date(@upload.created_at, include_time: true) %></dd>
   <dt class="col-sm-4 col-md-3">Status</dt>
   <dd class="col-sm-7 col-md-8" id="upload-status"><%= @upload.status.humanize %></dd>
   <dt class="col-sm-4 col-md-3">Records updated</dt>

--- a/app/views/annual_billing_data_files/index.html.erb
+++ b/app/views/annual_billing_data_files/index.html.erb
@@ -28,7 +28,7 @@
               <%= link_to File.basename(upload.filename),
                 regime_annual_billing_data_file_path(@regime, upload) %>
             </td>
-            <td><%= formatted_date(upload.created_at, true) %></td>
+            <td><%= formatted_date(upload.created_at, include_time: true) %></td>
             <td><%= upload.status.humanize %></td>
             <td><%= upload.failed_count %></td>
           </tr>

--- a/app/views/annual_billing_data_files/show.html.erb
+++ b/app/views/annual_billing_data_files/show.html.erb
@@ -8,7 +8,7 @@
     <dt class="col-sm-4 col-md-3">Filename</dt>
     <dd class="col-sm-7 col-md-8"><%= File.basename @view_model.upload.filename %></dd>
     <dt class="col-sm-4 col-md-3">Date uploaded</dt>
-    <dd class="col-sm-7 col-md-8"><%= formatted_date(@view_model.upload.created_at, true) %></dd>
+    <dd class="col-sm-7 col-md-8"><%= formatted_date(@view_model.upload.created_at, include_time: true) %></dd>
     <dt class="col-sm-4 col-md-3">Status</dt>
     <dd class="col-sm-7 col-md-8"><%= @view_model.upload.status.humanize %></dd>
     <dt class="col-sm-4 col-md-3">Records updated</dt>

--- a/app/views/data_export/_export_data_file.html.erb
+++ b/app/views/data_export/_export_data_file.html.erb
@@ -9,7 +9,7 @@
 <% else %>
   <dl class="row">
     <dt class="col-5 col-lg-6">Export file generated on:</dt>
-    <dd class="col-7 col-lg-6"><%= formatted_date(export_data_file.last_exported_at, true) %></dd>
+    <dd class="col-7 col-lg-6"><%= formatted_date(export_data_file.last_exported_at, include_time: true) %></dd>
   </dl>
 <% end %>
 <% if export_data_file.exported_filename %>


### PR DESCRIPTION
https://trello.com/c/szZDCqDO

Unfortunately, this was only spotted after the service went live after being updated to Ruby 2.7 and Rails 6. From the **Transactions** menu for each regime, there is a **Download Transaction Data** link.

This _should_ take you to a page that displays details about the zip file containing the transaction data including a link to it. Now, users get an Nginx 404 message (when clicking the link in AWS). Locally they get

```
Rendered layout layouts/application.html.erb (Duration: 3.8ms | Allocations: 1440)
wrong number of arguments (given 2, expected 1)
Completed 500 Internal Server Error in 15ms (ActiveRecord: 1.4ms | Allocations: 4057)

ActionView::Template::Error (wrong number of arguments (given 2, expected 1)):
     9: <% else %>
    10:   <dl class="row">
    11:     <dt class="col-5 col-lg-6">Export file generated on:</dt>
    12:     <dd class="col-7 col-lg-6"><%= formatted_date(export_data_file.last_exported_at, true) %></dd>
    13:   </dl>
    14: <% end %>
    15: <% if export_data_file.exported_filename %>

app/lib/formatting_utils.rb:28:in `formatted_date'
app/views/data_export/_export_data_file.html.erb:12
app/views/data_export/index.html.erb:10
app/views/data_export/index.html.erb:8
app/controllers/application_controller.rb:38:in `set_local_time'
```

What this actually highlights is 2-fold;

- we have an error in the view for the page
- when we get an error the service is failing to redirect users properly hence Nginx handles the 404 instead of the service)

This change fixes the link and ensures the page displays correctly. Fixing the failing redirect will need to be tackled in a separate change.

**Note on the fix**

The issue was that the view partial was calling the `app/lib/formatting_utils.rb -> formatted_date()` method and passing in a second arg. The signature for `formatted_date()` is

```ruby
  def formatted_date(date, include_time: false)
    format_date(date, "%d-%b-%Y", include_time)
  end
```

So, it has a keyword argument. Some Googling threw up that Ruby 2.7 has made changes to how keyword and optional arguments are handled in preparation for [changes proposed in Ruby 3.0](https://github.com/ruby/ruby/blob/4643bf5d55af6f79266dd67b69bb6eb4ff82029a/doc/NEWS-2.7.0#the-spec-of-keyword-arguments-is-changed-towards-30-). Admittedly, the documentation and [various blog posts](https://bigbinary.com/blog/ruby-2-7-deprecates-conversion-of-keyword-arguments) suggest we should have got some deprecation warning instead. The key thing is changes have definitely been made. Regardless, the code _should really_ have used the keyword then this error would never have been thrown.

<details>
<summary>Example screenshot</summary>

<img width="883" alt="Screenshot 2021-04-13 at 23 07 08" src="https://user-images.githubusercontent.com/1789650/114630086-b41ee480-9cb1-11eb-8005-fa70593bc695.png">

</details>
