### PR TITLE
Fix Upload Annual Billing Data page

### DIFF
--- a/app/helpers/annual_billing_helper.rb
+++ b/app/helpers/annual_billing_helper.rb
@@ -7,7 +7,7 @@ module AnnualBillingHelper
     items = ["<dl class='row'>"]
     send("#{regime.to_param}_columns").each do |c|
       items << "<dt class='col-sm-4 col-md-3'>#{c[:header].to_s.humanize.titlecase}</dt>"
-      items << "<dd class='col-sm-7 col-md-8'>#{Descriptions[c[:header]]}</dd>"
+      items << "<dd class='col-sm-7 col-md-8'>#{DESCRIPTIONS[c[:header]]}</dd>"
     end
     items << "</dl>"
     items.join.html_safe


### PR DESCRIPTION
Spotted that the page was erroring when working on [Fix broken download transaction data link](https://github.com/DEFRA/sroc-tcm-admin/pull/410)

```
NameError in AnnualBillingDataFiles#new

Showing /vagrant/sroc-tcm-admin/app/views/annual_billing_data_files/_csv_help.html.erb where line #11 raised:

uninitialized constant AnnualBillingHelper::Descriptions
Did you mean?  AnnualBillingHelper::DESCRIPTIONS

app/helpers/annual_billing_helper.rb:10:in `block in annual_billing_csv_column_descriptions_for'
app/helpers/annual_billing_helper.rb:8:in `each'
app/helpers/annual_billing_helper.rb:8:in `annual_billing_csv_column_descriptions_for'
app/views/annual_billing_data_files/_csv_help.html.erb:11
app/views/annual_billing_data_files/new.html.erb:14
app/views/annual_billing_data_files/new.html.erb:7
app/controllers/application_controller.rb:38:in `set_local_time'
```

TBH we're not sure how this ever worked. Ruby is a 'case-sensitive' language so `AnnualBillingHelper::Descriptions` and `AnnualBillingHelper::DESCRIPTIONS` are two entirely different things 🤷

<details>
<summary>Screenshot</summary>

<img width="589" alt="Screenshot 2021-04-14 at 00 22 20" src="https://user-images.githubusercontent.com/1789650/114632934-83da4480-9cb7-11eb-8414-e321e304d333.png">

</details>