### PR TITLE
Remove empty test files

### DIFF
--- a/test/controllers/transaction_summary_controller_test.rb
+++ b/test/controllers/transaction_summary_controller_test.rb
@@ -16,14 +16,4 @@ class TransactionSummaryControllerTest < ActionDispatch::IntegrationTest
     get regime_transaction_summary_index_url(@regime), xhr: true
     assert_redirected_to root_path
   end
-
-  # def test_index_should_return_406_if_not_json_request
-  #   get regime_transaction_summary_index_url(@regime)
-  #   assert_response :not_acceptable
-  # end
-
-  # def test_it_should_get_index_for_json
-  #   get regime_transaction_summary_index_url(@regime, format: :json)
-  #   assert_response :success
-  # end
 end

--- a/test/integration/read_only_transaction_details_test.rb
+++ b/test/integration/read_only_transaction_details_test.rb
@@ -5,10 +5,6 @@ require "test_helper"
 class ReadOnlyTransactionDetailsTest < ActionDispatch::IntegrationTest
   include RegimeSetup
 
-  def setup
-    # Capybara.current_driver = Capybara.javascript_driver
-  end
-
   def test_exclude_button_not_available
     setup_pas_read_only
     t = @regime.transaction_details.unbilled.last

--- a/test/models/annual_billing_data_upload_test.rb
+++ b/test/models/annual_billing_data_upload_test.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "test_helper"
-
-class AnnualBillingDataFileTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "test_helper"
-
-class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/services/put_data_export_file_test.rb
+++ b/test/services/put_data_export_file_test.rb
@@ -20,9 +20,9 @@ class PutDataExportFileTest < ActiveSupport::TestCase
     edf = @regime.export_data_file
     filename = edf.exported_filename
     path = File.join(@tmp_path, "csv", File.basename(filename))
-    File.delete(path) # if File.exists?(path)
+    File.delete(path)
     path = File.join(@cache_path, File.basename(filename))
-    File.delete(path) # if File.exists?(filename)
+    File.delete(path)
   end
 
   def test_it_copies_local_file_to_csv_export_store


### PR DESCRIPTION
On the face of it you could look at the folders in the `test/` directory and think we havve a number of things covered. Actually, when you start opening some of them up they are empty. Best guess is they were automatically added via the rails generator and never populated.

To avoid that confusion and to make it clearer what is and isn't covered by tests this change deletes any empty tests files.