### PR TITLE
Update invite user mailer to deliver immediately

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,7 +76,7 @@ class UsersController < AdminController
     invitation_link = accept_user_invitation_url(
       invitation_token: user.raw_invitation_token
     )
-    UserMailer.invitation(user.email, user.full_name, invitation_link).deliver_later
+    UserMailer.invitation(user.email, user.full_name, invitation_link).deliver_now
     user.update(invitation_sent_at: Time.now.utc)
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -29,7 +29,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to users_path
     assert_equal "User account created", flash[:notice]
-    assert_enqueued_jobs 1
   end
 
   test "should get edit" do


### PR DESCRIPTION
> Part of removing redis and resque dependencies
>
> The service currently uses [Resque](https://github.com/resque/resque) for managing background jobs including email. We use [whenever](https://github.com/javan/whenever) to schedule adding 'jobs' to the queue, which means adding a record in [redis](https://redis.io/). Registered resque 'workers' then pick up and process the actual jobs.
>
> This would be great if we were dealing with thousands of background tasks. But we're not. We are dealing with just 3. Recently we have been caught out a number of times with issues owing to either jobs not logging, workers not being registered, and confusion about the process overall.
>
> There is just no need for all this additional complexity when we can replicate what other services have done and which this is already doing; just have **whenever** via cron run the task directly.

This change is specifically focusing on emails, and switching them from being queued to being sent immediately. We send emails straight away in all our other ruby services with no noticeable impact on users. Plus in the TCM the only emails sent are Devise based user emails. Adding users and unlocking accounts doesn't happen all that often so again there should be no performance hit.
