### PR TITLE
Fix devise errors deprecation warning

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -4,7 +4,6 @@
   </div>
 </div>
 <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
-  <%#= devise_error_messages! %>
   <%= error_header(resource) %>
   <%= f.hidden_field :invitation_token %>
   <% if f.object.class.require_password_on_accepting %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,6 +1,5 @@
 <h2><%= t "devise.invitations.new.header" %></h2>
 <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
-  <%#= devise_error_messages! %>
   <%= error_header(resource) %>
 
 <% resource.class.invite_key_fields.each do |field| -%>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,7 +4,7 @@
   </div>
 </div>
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
   <%= render partial: 'shared/password_help' %>
   <div class="row">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="row">
     <div class="col-lg-6">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,6 @@
 </div>
 
 <%= form_for(resource, as: resource_name, url: user_registration_path, html: { method: :patch }) do |f| %>
-  <%#= devise_error_messages! %>
   <%= error_header(resource) %>
 
   <%= render partial: 'shared/password_help' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Sign up</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="row">
     <div class="col-lg-6">


### PR DESCRIPTION
Whilst working on [Update invite user mailer to deliver immediately](https://github.com/DEFRA/sroc-tcm-admin/pull/424) we spotted this warning in the logs

```
DEPRECATION WARNING: [Devise] `DeviseHelper#devise_error_messages!` is deprecated and will be
removed in the next major version.

Devise now uses a partial under "devise/shared/error_messages" to display
error messages by default, and make them easier to customize. Update your
views changing calls from:

    <%= devise_error_messages! %>

to:

    <%= render "devise/shared/error_messages", resource: resource %>

To start customizing how errors are displayed, you can copy the partial
from devise to your `app/views` folder. Alternatively, you can run
```

This change resolves the error by adding the shared partial and updating the existing references.