### PR TITLE
Fix dependabot builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,24 @@
 name: CI
 
-on: push
+# We want this workflow to trigger when
+#
+# - a change is made to `main` either because of a direct push or when a PR is merged
+# - whenever a PR is created or updated by a team member
+# - whenever a PR is created or updated by Dependabot
+#
+# That last scenario is what triggers `pull_request_target` to be fired but it is insecure and can allow malicious
+# access to repo secrets. This is why we also add the activity type 'labeled'. Only those with write permissions to the
+# repo are able to add labels to PR's, which is our way of determining the PR came from Dependabot rather than an
+# anonymous user
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   build:


### PR DESCRIPTION
We use [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) to

> [..] keep the packages you use updated to the latest versions.

Back in 2020 we also switched this project plus a number of other Defra ones to use [GitHub Actions](https://github.com/features/actions) instead of [Travis CI](https://www.travis-ci.com/). Travis brought in a [new pricing plan](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) that limited the build minutes to 1000 minutes per month which caused builds to start failing across all our projects.

This worked fine until Feb 2021 when GitHub made a change [to the permissions Dependabot PRs](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) have. The TL;DR is that workflows triggered by Dependabot would no longer have access to repo secrets.

Our CI workflow needs access to these because they contain the `SONAR_TOKEN` used to authenticate and send SonarQube's analysis results to [SonarCloud](https://sonarcloud.io/project/overview?id=DEFRA_sroc-charging-module-api). Because this step in the workflow started failing, all Dependabot PRs failed.

We have been able to work around the problem by [manually restarting jobs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#manually-re-running-a-workflow). This has the effect of changing the context such that GitHub sees a recognised owner of the repo and thus grants access to secrets. But it's not ideal.

Both in the [docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions) and a [blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) that accompanied the announcement GitHub suggest the ideal solution is to break up your workflow into 2. The first does any actions that are at risk in the locked-down context and then the second does whatever actions that need access to secrets. Our issue is SonarCloud needs access to both the code and the output of running the tests. Artifacts can be transferred between workflows but it does vastly increase the complexity of the CI pipeline. Plus we saw [reports of it still not working](https://github.community/t/dependabot-doesnt-see-github-actions-secrets/167104/3).

As an alternate, GitHub also suggests watching for the [pull_request_target](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events) and triggering your CI from that. This runs the workflow with the same permissions Dependabot used to have but also exposes you to [malicious pull requests that can access your repo secrets](https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests). The way to protect yourself is to include checks that the PR has come from a recognised source. You can do this by checking the [github.actor](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context) in the workflow.

```yaml
jobs:
  dependabot:
    runs-on: ubuntu-latest
    if: ${{ github.actor == 'dependabot[bot]' }}
    steps:
      - uses: actions/checkout@v2
        with:
          # Check out the pull request HEAD
          ref: ${{ github.event.pull_request.head.sha }}
          github-token: ${{ secrets.GITHUB_TOKEN }}
```

Another way is to only trigger the workflow for the [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event if the activity type is 'labeled'. Only those with write privileges to the repo have the ability to label a PR. So, anonymous PR's will not trigger the workflow to run.

The first solution is more explicit but has issues. If your workflow is also used for other events like pull requests and pushes to `main` you have to decide to either

- duplicate the workflow; have one triggered by safe events without the check and the other with the check
- add in a long `if` condition; for each scenario (unsafe PR from Dependabot, safe PR from a team member, push to main, etc) you have to include it as a condition to ensure the workflow gets run

The second solution is less explicit but avoids these issues, which is why it's the one we have gone for. So, this change updates our current CI workflow to allow Dependabot PR's to pass CI in the future by updating what events trigger it to run.