### PR TITLE
Fix dependabot PR's (attempt 2!)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,15 @@ name: CI
 # - whenever a PR is created or updated by Dependabot
 #
 # That last scenario is what triggers `pull_request_target` to be fired but it is insecure and can allow malicious
-# access to repo secrets. This is why we also add the activity type 'labeled'. Only those with write permissions to the
-# repo are able to add labels to PR's, which is our way of determining the PR came from Dependabot rather than an
-# anonymous user
+# access to repo secrets. This is why we also have a big 'if' condition to ensure the build only runs when
+# `pull_request_target` is triggered if its a Dependabot PR.
+#
+# Documents that discuss some of this
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events
 # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# Credit to https://github.com/davidboike who posted a link to his solution in the GitHub community
+# https://github.community/t/dependabot-doesnt-see-github-actions-secrets/167104/42
 on:
   push:
     branches:


### PR DESCRIPTION
It turns out what we thought would work in [Fix dependabot builds](https://github.com/DEFRA/sroc-tcm-admin/pull/458) simply doesn't. We think having both `pull_request` and `pull_request_target` as triggers means GitHub is just triggering `pull_request` as it sees them as duplicates.

So, with this change, we are trying option 1. That remove 'labeled' from `pull_request_target` as a trigger and add a big `if` condition that governs if the job can run.

> Credit to https://github.com/davidboike for this. See https://github.community/t/dependabot-doesnt-see-github-actions-secrets/167104/42