### PR TITLE
Reset the Dependabot build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,6 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      - name: Debug
-        run: |
-          echo "Actor is ${{ github.actor }}"
-
       # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
       # version from .ruby-verion itself
       - name: Install Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,10 @@
 name: CI
 
-# We want this workflow to trigger when
-#
-# - a change is made to `master` either because of a direct push or when a PR is merged
-# - whenever a PR is created or updated by a team member
-# - whenever a PR is created or updated by Dependabot
-#
-# That last scenario is what triggers `pull_request_target` to be fired but it is insecure and can allow malicious
-# access to repo secrets. This is why we also have a big 'if' condition to ensure the build only runs when
-# `pull_request_target` is triggered if its a Dependabot PR.
-#
-# Documents that discuss some of this
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events
-# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-#
-# Credit to https://github.com/davidboike who posted a link to his solution in the GitHub community
-# https://github.community/t/dependabot-doesnt-see-github-actions-secrets/167104/42
 on:
   push:
-    branches:
-      - master
-  pull_request:
-  pull_request_target:
 
 jobs:
   build:
-    if: |
-      (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
-      github.event_name == 'push'
     # You must use a Linux environment when using service containers or container jobs
     runs-on: ubuntu-latest
     env:
@@ -61,19 +37,13 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Checkout repository
-        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      # For Dependabot PR's which are triggered from pull_request_target if we don't specify a specific ref we'll just
-      # end up checking out the PR base branch
-      - name: Checkout repository (dependabot)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2
-        with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+      - name: Debug
+        run: |
+          echo "Actor is ${{ github.actor }}"
 
       # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
       # version from .ruby-verion itself
@@ -103,6 +73,7 @@ jobs:
           sed -i 's/\/home\/runner\/work\/sroc-tcm-admin\/sroc-tcm-admin\//\/github\/workspace\//g' coverage/.resultset.json
 
       - name: Analyze with SonarCloud
+        if: github.actor != 'dependabot[bot]'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub


### PR DESCRIPTION
In [Fix dependabot builds](https://github.com/DEFRA/sroc-tcm-admin/pull/458) we attempted to solve a problem we have been facing with running sonar cloud analysis for Dependabot builds. The original PR goes into detail but TL;DR Dependabot is not allowed access to the sonar token needed to authenticate with SonarCloud.

We thought based on our research of GitHub actions and other's solutions that we had cracked it. However, something still isn't right. We can get the CI build to pass and even the SonarCloud analysis to run but we get no update back from SonarCloud. We always have SonarCloud as a required check so this means we are still left with a stuck PR.

After discussing it as a team, until we can properly crack this nut we feel the best solution is to reset our changes and add a new one that skips the SonarCloud analysis if the actor is Dependabot. The PR will still remain stuck but the checks will more accurately reflect what is going on.

<details>
<summary>PR checks before</summary>

<img width="777" alt="Screenshot 2021-09-09 at 09 05 32" src="https://user-images.githubusercontent.com/1789650/132648155-a361653a-64e6-4507-a3e9-2ce932d3fa0f.png">

</details>