### PR TITLE
Update dev environment config for web console

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-  config.web_console.whitelisted_ips = "10.0.0.0/8"
-
   # recompile webpack files as we make changes
   config.x.webpacker[:dev_server_host]
 
@@ -74,4 +71,16 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # The rails web console allows you to execute arbitrary code on the server. By
+  # default, only requests coming from IPv4 and IPv6 localhosts are allowed.
+  # When running in a vagrant box it'll use a different IP e.g. 10.0.2.2 so
+  # to stop getting `Cannot render console from 10.0.2.2!` in the logs you need
+  # to add its IP to this white list. The SSH_CLIENT holds this value but it
+  # contains some other stuff as well e.g. 10.0.2.2 59811 22. Hence we use fetch
+  # so we can assign the default (for none vagrant boxes) else grab the env var
+  # but just the first part of it.
+  # https://github.com/rails/web-console#configuration
+  # https://stackoverflow.com/a/29417509
+  config.web_console.whitelisted_ips = ENV.fetch("SSH_CLIENT", "127.0.0.1").split(" ").first
 end


### PR DESCRIPTION
This was initially spotted because it was flagged as a security issue by SonarCloud

> Make sure using this hardcoded IP address is safe here.
>
> https://sonarcloud.io/project/security_hotspots?id=DEFRA_sroc-tcm-admin&hotspots=AXVNs2NhSMXK6iHBcFTo

When reviewing we spotted the current config does not match the setup we have on other services such as [waste-exemptions-back-office](https://github.com/DEFRA/waste-exemptions-back-office/blob/main/config/environments/development.rb) and [waste-carriers-back-office](https://github.com/DEFRA/waste-carriers-back-office/blob/main/config/environments/development.rb). Like the TCM we typically run our Rails apps in Vagrant boxes and the config in those projects take that into account.

So, this change updates the TCM to match those other projects. We also hope it will resolve the SonarCloud error!