### PR TITLE
Turn on translation errors

### DIFF
--- a/app/views/transactions/_cfd_related_unbilled.html.erb
+++ b/app/views/transactions/_cfd_related_unbilled.html.erb
@@ -8,7 +8,7 @@
       <th><%= th :consent_reference %></th>
       <th><%= th :version_html %></th>
       <th><%= th :discharge_html %></th>
-      <th><%= th :category %></th>
+      <th><%= th :sroc_category %></th>
       <th><%= th :confidence_level_html %></th>
       <th><%= th :variation %></th>
       <th><%= th :temporary_cessation %></th>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,5 +40,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,5 +40,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,9 @@ en:
         removed_at: 'Removal Date'
         removal_reference: 'Support Incident No.'
         removal_reason: 'Reason for Removal'
+      permit_categories:
+        code: 'Code'
+        description: 'Description'
   views:
     amount_with_unit: "Amount (£)"
     pagination:


### PR DESCRIPTION
Rails views are a combination of the structure defined in the `*.html.erb` and content (also known as 'translation') from `config/locales`. It's how Rails can support multi-language and locale websites out-of-the-box.

On other Defra ruby services our convention has always been to have Rails raise an exception if a translation is missing when running in the `development` and `test` environments. We turn it off in `production` as generally the fallback is sufficient and we don't want some wonky text to block users from being able to use the system.

We've spotted the TCM isn't set up in the same way as our other services and currently has errors turned off. This change updates the TCM config to bring it in line and see if we can't catch some missing translations!