### PR TITLE
Remove jobs folder

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationJob < ActiveJob::Base
-end


### PR DESCRIPTION
We got rid of the need for ActiveJob based background jobs in previous commits when we removed the dependency on Resque and Redis.

We still have a jobs folder with an unused base Activejob class. So, this change removes the folder as part of our efforts to tidy up the TCM project.