### PR TITLE
Add spec for DataExportController

### DIFF
--- a/app/controllers/data_export_controller.rb
+++ b/app/controllers/data_export_controller.rb
@@ -2,7 +2,7 @@
 
 class DataExportController < ApplicationController
   include RegimeScope
-  before_action :set_regime, only: %i[index download generate]
+  before_action :set_regime, only: %i[index download]
 
   # GET /regimes/:regime_id/data_export
   def index; end
@@ -15,14 +15,5 @@ class DataExportController < ApplicationController
       redirect_to regime_data_export_index_path(@regime),
                   alert: "Unable to retrieve data file! Please try again later or contact the support desk."
     end
-  end
-
-  def generate
-    raise ActionController::RoutingError, "Not Found" unless SystemConfig.config.can_generate_export?
-
-    DataExportService.call(regime: @regime)
-
-    redirect_to regime_data_export_index_path(@regime),
-                notice: "Your export has been generated."
   end
 end

--- a/app/views/data_export/_export_data_file.html.erb
+++ b/app/views/data_export/_export_data_file.html.erb
@@ -19,10 +19,3 @@
       class: "btn btn-primary", data: { turbolinks: false } %>
   </div>
 <% end %>
-<% if SystemConfig.config.can_generate_export? %>
-  <div class="mt-4">
-    <%= link_to "TEST: Regenerate Export File",
-      generate_regime_data_export_index_path(@regime),
-      class: "btn btn-warning", data: { turbolinks: false } %>
-  </div>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,6 @@ Rails.application.routes.draw do
     resources :exclusion_reasons, except: [:show]
     resources :data_export, only: [:index] do
       get "download", on: :collection
-      get "generate", on: :collection
     end
   end
 

--- a/db/migrate/20211108161905_remove_can_generate_export_from_system_config.rb
+++ b/db/migrate/20211108161905_remove_can_generate_export_from_system_config.rb
@@ -1,0 +1,5 @@
+class RemoveCanGenerateExportFromSystemConfig < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :system_configs, :can_generate_export, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_204115) do
+ActiveRecord::Schema.define(version: 2021_11_08_161905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,7 +161,6 @@ ActiveRecord::Schema.define(version: 2021_10_05_204115) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "process_retrospectives", default: true, null: false
-    t.boolean "can_generate_export", default: false, null: false
   end
 
   create_table "transaction_details", force: :cascade do |t|
@@ -331,7 +330,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_204115) do
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end

--- a/spec/requests/data_export_spec.rb
+++ b/spec/requests/data_export_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Data Export", type: :request do
+  let(:regime) { create(:regime) }
+
+  describe "/regimes/:regime_id/data_export" do
+    context "when a user is signed in" do
+      let(:user) { create(:user_with_regime, :billing, regime: regime) }
+
+      before do
+        sign_in(user)
+      end
+
+      it "returns a 200 response" do
+        get regime_data_export_index_path(regime)
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a user is not signed in" do
+      subject { get regime_data_export_index_path(regime) }
+
+      it "redirects to the sign in page" do
+        expect(subject).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "/regimes/:regime_id/data_export/download" do
+    context "when a user is signed in" do
+      let(:user) { create(:user_with_regime, :billing, regime: regime) }
+      let(:result_struct) do
+        Struct.new(:success) do
+          def success?
+            success
+          end
+
+          def filename
+            Rails.root.join("spec", "fixtures", "export_files", "cfd_transactions.csv")
+          end
+        end
+      end
+
+      before(:each) do
+        sign_in(user)
+        allow_any_instance_of(FetchDataExportFile).to receive(:call).and_return(result_struct.new(file_found))
+      end
+
+      context "and there is a file to download" do
+        let(:file_found) { true }
+
+        it "returns a 200 response" do
+          get download_regime_data_export_index_path(regime)
+
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "but there is no file to download" do
+        let(:file_found) { false }
+
+        subject { get download_regime_data_export_index_path(regime) }
+
+        it "redirects to the data export index page and displays a flash alert message" do
+          expect(subject).to redirect_to(regime_data_export_index_path(regime))
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+
+    context "when a user is not signed in" do
+      subject { get download_regime_data_export_index_path(regime) }
+
+      it "redirects to the sign in page" do
+        expect(subject).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-190

As part of our efforts to increase unit test coverage for the project, we spotted that some controllers have little to no unit test coverage.

This change adds a spec for the `DataExportController` which currently has 0% coverage.