### PR TITLE
Add exclusion reasons to seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,6 +53,16 @@ PermitCategoryImporter.import(r, Rails.root.join("db", "categories", "installati
   SequenceCounter.find_or_create_by(regime_id: r.id, region: region)
 end
 
+[
+  "Extra line auto-created by feeder system",
+  "Extra line created by PAS manual invoice function (permit category)",
+  "Extra line created by PAS manual invoice function (temporary cessation)",
+  "Incorrect Compliance Band in PAS file",
+  "Pre-Construction site charge rate set to zero"
+].each do |reason|
+  ExclusionReason.find_or_create_by(regime_id: r.id, reason: reason)
+end
+
 r = Regime.find_by!(slug: "cfd")
 r.permit_categories.destroy_all
 PermitCategoryImporter.import(r, Rails.root.join("db", "categories", "water_quality.csv"))
@@ -61,12 +71,31 @@ PermitCategoryImporter.import(r, Rails.root.join("db", "categories", "water_qual
   SequenceCounter.find_or_create_by(regime_id: r.id, region: region)
 end
 
+[
+  "Transaction line not required to generate correct bill"
+].each do |reason|
+  ExclusionReason.find_or_create_by(regime_id: r.id, reason: reason)
+end
+
 r = Regime.find_by!(slug: "wml")
 r.permit_categories.destroy_all
 PermitCategoryImporter.import(r, Rails.root.join("db", "categories", "waste.csv"))
 
 %w[A B E N S T U Y].each do |region|
   SequenceCounter.find_or_create_by(regime_id: r.id, region: region)
+end
+
+[
+  "Credit note for invoice that was never issued",
+  "Extra line created by PAS manual invoice function (permit category)",
+  "Embargoed TX (Permit edit during AB shutdown)",
+  "Invoice generated in error",
+  "Invoice incorrect",
+  "No charge code provided",
+  "Permit edit pending",
+  "Transfer/variation/surrender processed in error"
+].each do |reason|
+  ExclusionReason.find_or_create_by(regime_id: r.id, reason: reason)
 end
 
 # add region to all transactions


### PR DESCRIPTION
The [sroc-tcm-acceptance-tests](https://github.com/DEFRA/sroc-tcm-acceptance-tests/pull/48) is the temporary home of a selenium test of the TCM. Previously, it only worked if you were lucky enough to have data in the environment you were running against which matched what the test needed.

We now have some test files we can manually import before running the test. Ideally, to get a consistent run we reset the environment first (reset the DB and then re-seed). When we recently tried this though we hit a problem. When the DB is reset all exclusion reasons are deleted and the test expects some to exist.

Exlcusion reasons are something managed by the user. However, they appear to have been created when the project went live and then left as is. This might explain why they were not previously included in the seeding. But we need them now to ensure our acceptance tests pass as they are critical to signing off each TCM release.

This change adds generating exclusion reasons to the seeding process. We've just gone with what we found in `production` as it appears to be a fixed list.