### PR TITLE
Remove references to vagrant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: pinafore
-          POSTGRES_DB: sroc-tcm-admin_test
+          POSTGRES_DB: sroc_tcm_test
         # Maps tcp port 5432 on service container to the host
         ports:
           - 5432:5432

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,20 +3,21 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV["RAILS_MAX_THREADS"] || 5 %>
+  pool: 5
   host: <%= ENV["POSTGRES_HOST"] || "localhost" %>
   port: <%= ENV["POSTGRES_PORT"] || 5432 %>
-  username: <%= ENV["POSTGRES_USER"] || "vagrant" %>
-  password: <%= ENV["POSTGRES_PASSWORD"] || "vagrant" %>
+  username: <%= ENV["POSTGRES_USER"] || "tcm" %>
+  password: <%= ENV["POSTGRES_PASSWORD"] || "password" %>
 
 development:
   <<: *default
-  database: <%= ENV["POSTGRES_DB"] || "sroc-tcm-admin" %>
+  database: <%= ENV["POSTGRES_DB"] || "sroc_tcm_dev" %>
 
 test:
   <<: *default
-  database: <%= ENV["POSTGRES_DB_TEST"] || "sroc-tcm-admin_test" %>
+  database: <%= ENV["POSTGRES_DB_TEST"] || "sroc_tcm_test" %>
+  min_messages: WARNING
 
 production:
   <<: *default
-  database: <%= ENV["POSTGRES_DB"] || "sroc" %>
+  database: <%= ENV["POSTGRES_DB"] || "sroc_tcm" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,21 +71,20 @@ Rails.application.configure do
 
   # The rails web console allows you to execute arbitrary code on the server. By
   # default, only requests coming from IPv4 and IPv6 localhosts are allowed.
-  # When running in a vagrant box it'll use a different IP e.g. 10.0.2.2 which
-  # leads `Cannot render console from 10.0.2.2!` appearing in the logs. Exactly
-  # the same issue applies when running in a Docker container. You need to add
-  # either the Vagrant or Docker IP to `whitelisted_ips`.
+  # When not running on directly on the host, for example in a Docker container
+  # it'll use a different IP which causes `Cannot render console from 10.0.2.2!`
+  # to appear in the logs. To fix this you need to add the Docker IP to
+  # `whitelisted_ips`.
   #
-  # In vagrant SSH_CLIENT holds this value but it contains some other stuff as
-  # well e.g. 10.0.2.2 59811 22. Hence we use fetch so we can assign the default
-  # (for none vagrant boxes) else grab the env var but just the first part of
-  # it.
   # https://github.com/rails/web-console#configuration
   # https://stackoverflow.com/a/29417509
+  #
+  # We only set the env var LOG_TO_STDOUT to 1 if running in a docker container
+  # which is why our logic hinges on it
   if ENV.fetch("LOG_TO_STDOUT", "0") == "1"
     host_ip = `/sbin/ip route|awk '/default/ { print $3 }'`.strip
     config.web_console.whitelisted_ips = host_ip
   else
-    config.web_console.whitelisted_ips = ENV.fetch("SSH_CLIENT", "127.0.0.1").split(" ").first
+    config.web_console.whitelisted_ips = "127.0.0.1"
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-284

When we first joined the team there was no quick way to get a working TCM environment up and running. There wasn’t even much documentation.

On the Ruby Services team, we ensured each service had a [vagrant](https://www.vagrantup.com/) development environment. Vagrant is essentially a way to codify the installation and setup for your app, including all the things it depends on, for example, the database service.

This means new members can get up and running in minutes and the vagrant code acts as documentation for how to create a working environment.

This was one of the first things the new team did for the TCM. But with us now moving to Docker the Vagrant environment is defunct. Instead, we’ll be using Docker and [Docker Compose](https://docs.docker.com/compose/) to do the same thing.

This change removes all references to Vagrant.