### PR TITLE
Update logging and use JSON format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,8 @@ GTM_CODE=gtm_code_goes_here
 
 # Pseudo-random key to use for your session secret. Generate one using `bundle exec rake secret`
 SECRET_KEY_BASE=secret_key_goes_here
+
+# Logging level
+# We default the level to :info but you can use the env var to override it, for example, to :debug when working
+# locally
+LOG_LEVEL=info

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "kaminari"
 # on other Defra services this replaces passenger.
 gem "puma"
 gem "rails-i18n"
+gem "rails_semantic_logger"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 5.0"
 gem "secure_headers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,10 @@ GEM
     rails-i18n (7.0.2)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_semantic_logger (4.10.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.9)
     railties (7.0.2.2)
       actionpack (= 7.0.2.2)
       activesupport (= 7.0.2.2)
@@ -321,6 +325,8 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.10.0)
+      concurrent-ruby (~> 1.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -398,6 +404,7 @@ DEPENDENCIES
   rails (>= 6.1.3.1)
   rails-controller-testing
   rails-i18n
+  rails_semantic_logger
   rspec-rails
   sass-rails (~> 5.0)
   secure_headers

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,7 @@ module SrocTcmAdmin
     #
     # Our default log level is :info but we allow for this to be overidden using an env var, for example, when running
     # lovcally and you need to switch to :debug.
-    config.log_level =  ENV.fetch("LOG_LEVEL", "info").downcase.strip.to_sym
+    config.log_level = ENV.fetch("LOG_LEVEL", "info").downcase.strip.to_sym
     config.log_tags = {
       request_id: :request_id
     }

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,38 @@ module SrocTcmAdmin
 
     # exception handling
     config.exceptions_app = routes
+
+    # Logging configuration
+    #
+    # First thing to note is we use https://github.com/reidmorrison/semantic_logger rather than the default rails
+    # logger. We needed something that would format the logs as JSON and eliminate the noise. This is so that we can
+    # take advantage of the https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html in AWS
+    # Cloudwatch.
+    #
+    # We also need to cater for running in Docker. We don't want Rails logging to file. We need it logging to STDOUT
+    # so we can capture the output from the containers to see it locally and capture it in AWS Cloudwatch.
+    #
+    # Our default log level is :info but we allow for this to be overidden using an env var, for example, when running
+    # lovcally and you need to switch to :debug.
+    config.log_level =  ENV.fetch("LOG_LEVEL", "info").downcase.strip.to_sym
+    config.log_tags = {
+      request_id: :request_id
+    }
+    # Disable the logging of views and partials rendered (plus their metrics). In general we consider noise rather than
+    # helpful.
+    # Also, disable logging of asset retrievals in the :debug log as they are extremely noisy and clutter up the debug
+    # logs
+    config.rails_semantic_logger.rendered = false
+    config.rails_semantic_logger.quiet_assets = true
+
+    if ENV.fetch("LOG_TO_STDOUT", "0") == "1"
+      # Normally `puts` does not write immediately to `STDOUT`, but buffers the strings internally and writes the output
+      # in bigger chunks. To instead write immediately to `STDOUT` you set it into 'sync' mode. We want this behaviour
+      # to ensure nothing is missed from the logs in the case the container is killed unexpectedly.
+      $stdout.sync = true
+      # Configure semantic logger to not log to file and instead log to STDOUT in JSON format
+      config.rails_semantic_logger.add_file_appender = false
+      config.semantic_logger.add_appender(io: $stdout, formatter: :json)
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,7 @@ module SrocTcmAdmin
     #
     # We need to cater for running in Docker. We don't want Rails logging to file. We need it logging to STDOUT so we
     # can capture the output from the containers to see it locally and in AWS Cloudwatch.
-    if  ENV.fetch("LOG_TO_STDOUT", "0") == "1"
+    if ENV.fetch("LOG_TO_STDOUT", "0") == "1"
       # The only exception is when running our unit tests in a container. If we wrote the log to STDOUT then our
       # minitest and rspec output would be messed up log messages. This is because normally rspec will be writing to
       # STDOUT and Rails will be writing to a file. When we tell Rails to also write to STDOUT during a test we mess up

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,20 +62,19 @@ module SrocTcmAdmin
     #
     # We need to cater for running in Docker. We don't want Rails logging to file. We need it logging to STDOUT so we
     # can capture the output from the containers to see it locally and in AWS Cloudwatch.
-    if ENV.fetch("LOG_TO_STDOUT", "0") == "1"
-      # The only exception is when running our unit tests in a container. If we wrote the log to STDOUT then our
-      # minitest and rspec output would be messed up log messages. This is because normally rspec will be writing to
-      # STDOUT and Rails will be writing to a file. When we tell Rails to also write to STDOUT during a test we mess up
-      # the output.
-      unless Rails.env.test?
-        # Normally `puts` does not write immediately to `STDOUT`, but buffers the strings internally and writes the
-        # output in bigger chunks. To instead write immediately to `STDOUT` you set it into 'sync' mode. We want this
-        # behaviour to ensure nothing is missed from the logs in the case the container is killed unexpectedly.
-        $stdout.sync = true
-        # Configure semantic logger to not log to file and instead log to STDOUT in JSON format
-        config.rails_semantic_logger.add_file_appender = false
-        config.semantic_logger.add_appender(io: $stdout, formatter: :json)
-      end
+    #
+    # The only exception is when running our unit tests in a container. If we wrote the log to STDOUT then our
+    # minitest and rspec output would be messed up log messages. This is because normally rspec will be writing to
+    # STDOUT and Rails will be writing to a file. When we tell Rails to also write to STDOUT during a test we mess up
+    # the output.
+    if ENV.fetch("LOG_TO_STDOUT", "0") == "1" && Rails.env.test? == false
+      # Normally `puts` does not write immediately to `STDOUT`, but buffers the strings internally and writes the
+      # output in bigger chunks. To instead write immediately to `STDOUT` you set it into 'sync' mode. We want this
+      # behaviour to ensure nothing is missed from the logs in the case the container is killed unexpectedly.
+      $stdout.sync = true
+      # Configure semantic logger to not log to file and instead log to STDOUT in JSON format
+      config.rails_semantic_logger.add_file_appender = false
+      config.semantic_logger.add_appender(io: $stdout, formatter: :json)
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,16 +39,14 @@ module SrocTcmAdmin
 
     # Logging configuration
     #
-    # First thing to note is we use https://github.com/reidmorrison/semantic_logger rather than the default rails
-    # logger. We needed something that would format the logs as JSON and eliminate the noise. This is so that we can
-    # take advantage of the https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html in AWS
+    # We use https://github.com/reidmorrison/semantic_logger rather than the default rails logger. We needed something
+    # that would format the logs as JSON and eliminate the noise. This is so that we can take advantage of the
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html in AWS
     # Cloudwatch.
     #
-    # We also need to cater for running in Docker. We don't want Rails logging to file. We need it logging to STDOUT
-    # so we can capture the output from the containers to see it locally and capture it in AWS Cloudwatch.
     #
     # Our default log level is :info but we allow for this to be overidden using an env var, for example, when running
-    # lovcally and you need to switch to :debug.
+    # locally and you need to switch to :debug.
     config.log_level = ENV.fetch("LOG_LEVEL", "info").downcase.strip.to_sym
     config.log_tags = {
       request_id: :request_id
@@ -60,14 +58,24 @@ module SrocTcmAdmin
     config.rails_semantic_logger.rendered = false
     config.rails_semantic_logger.quiet_assets = true
 
-    if ENV.fetch("LOG_TO_STDOUT", "0") == "1"
-      # Normally `puts` does not write immediately to `STDOUT`, but buffers the strings internally and writes the output
-      # in bigger chunks. To instead write immediately to `STDOUT` you set it into 'sync' mode. We want this behaviour
-      # to ensure nothing is missed from the logs in the case the container is killed unexpectedly.
-      $stdout.sync = true
-      # Configure semantic logger to not log to file and instead log to STDOUT in JSON format
-      config.rails_semantic_logger.add_file_appender = false
-      config.semantic_logger.add_appender(io: $stdout, formatter: :json)
+    # Loggoing output
+    #
+    # We need to cater for running in Docker. We don't want Rails logging to file. We need it logging to STDOUT so we
+    # can capture the output from the containers to see it locally and in AWS Cloudwatch.
+    if  ENV.fetch("LOG_TO_STDOUT", "0") == "1"
+      # The only exception is when running our unit tests in a container. If we wrote the log to STDOUT then our
+      # minitest and rspec output would be messed up log messages. This is because normally rspec will be writing to
+      # STDOUT and Rails will be writing to a file. When we tell Rails to also write to STDOUT during a test we mess up
+      # the output.
+      unless Rails.env.test?
+        # Normally `puts` does not write immediately to `STDOUT`, but buffers the strings internally and writes the
+        # output in bigger chunks. To instead write immediately to `STDOUT` you set it into 'sync' mode. We want this
+        # behaviour to ensure nothing is missed from the logs in the case the container is killed unexpectedly.
+        $stdout.sync = true
+        # Configure semantic logger to not log to file and instead log to STDOUT in JSON format
+        config.rails_semantic_logger.add_file_appender = false
+        config.semantic_logger.add_appender(io: $stdout, formatter: :json)
+      end
     end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,13 +47,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :warn
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -63,19 +56,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-285

Prior to this change, the TCM used the standard Rails logger. It is very verbose but difficult to actually use when investigating issues. We access it via the AWS console (using CloudWatch) for our non-production and production environments.

```
Started GET "/auth/sign_in" for 172.19.0.1 at 2022-02-23 17:25:58 +0000
 Processing by Devise::SessionsController#new as HTML
   Rendering layout layouts/application.html.erb
   Rendering devise/sessions/new.html.erb within layouts/application
   Rendered devise/shared/_links.html.erb (Duration: 2.1ms | Allocations: 545)
   Rendered devise/sessions/new.html.erb within layouts/application (Duration: 68.4ms | Allocations: 4599)
   Rendered shared/_menu.html.erb (Duration: 1.7ms | Allocations: 339)
   Rendered layouts/_header.html.erb (Duration: 3.8ms | Allocations: 573)
   Rendered shared/_notices.html.erb (Duration: 1.6ms | Allocations: 196)
   Rendered layouts/_footer.html.erb (Duration: 1.9ms | Allocations: 104)
   Rendered layout layouts/application.html.erb (Duration: 5293.3ms | Allocations: 407460)
 Completed 200 OK in 5369ms (Views: 5335.3ms | ActiveRecord: 4.5ms | Allocations: 425177)
```

The [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) on the other hand logs everything as JSON and only outputs relevant information. Because it uses a standard JSON format it means we can leverage [Metric Filters](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) to easily find the information we need.

As part of moving the TCM to a Docker-based environment, we want to take this opportunity to ensure the logs are usable.