### PR TITLE
Add restart VSCode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,6 +34,21 @@
       }
     },
     {
+      "label": "🔄 Restart (TCM)",
+      "detail": "Restart just the app container",
+      "type": "shell",
+      "command": "docker-compose stop app && GIT_COMMIT=$(git rev-parse HEAD) docker-compose start app",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "never",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
       "label": "🛑 STOP (TCM)",
       "detail": "Stop all running containers",
       "type": "shell",
@@ -43,7 +58,7 @@
         "echo": true,
         "reveal": "always",
         "focus": true,
-        "panel": "dedicated",
+        "panel": "shared",
         "showReuseMessage": false,
         "clear": true
       }


### PR DESCRIPTION
The node restart works differently from how Rails does it. In Node, we actually use a package called nodemon which watches for changes in files When it sees one it simply restarts the app. This could be any file (depending on configuration).

In Rails the app is not restarted but nothing is preloaded when running locally. This means if you change code in a controller, model or view then you will see the change because the file is dynamically loaded when needed.

But some things are not covered by this, for example, anything in the `config/` folder. So, there are times we make a change and need to manually reload the app to see it.

Rather than kill everything (docker down && docker up) we have added a VSCode task that selectively stops and restarts just the app container.

Whilst doing this, we also spotted that the **STOP** task was misconfigured to use a dedicated panel.