### PR TITLE
Add ability to read last email for testing

### DIFF
--- a/app/controllers/last_email_controller.rb
+++ b/app/controllers/last_email_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LastEmailController < ActionController::Base
+  def show
+    render json: LastEmailCache.instance.last_email_json
+  end
+end

--- a/app/lib/last_email_cache.rb
+++ b/app/lib/last_email_cache.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class LastEmailCache
+  include Singleton
+
+  EMAIL_ATTRIBUTES = %i[date from to bcc cc reply_to subject].freeze
+
+  attr_accessor :last_email
+
+  # This is necessary to properly test the service functionality
+  def reset
+    @last_email = nil
+  end
+
+  def last_email_json
+    return JSON.generate(error: "No emails sent.") unless last_email.present?
+
+    message_hash = {}
+    EMAIL_ATTRIBUTES.each do |attribute|
+      message_hash[attribute] = last_email.public_send(attribute)
+    end
+    message_hash[:body] = email_body
+    message_hash[:attachments] = last_email.attachments.map(&:filename)
+
+    JSON.generate(last_email: message_hash)
+  end
+
+  # If you've set multipart emails then you'll have both a text and a html
+  # version (determined by adding the relevant erb views). If you do so then
+  # `my_mail.parts.length` will at least equal 2. If you only have one of them
+  # e.g. just a text version then parts doesn't get populated.
+  #
+  # However any attachments will cause ActionMailer to use parts. So for example
+  # if we have a text only email with an attached image, then parts will be of
+  # length 2; one being the content and the other being the attachment.
+  #
+  # To cater for all possibilities we have this method to grab the body content
+  # https://guides.rubyonrails.org/action_mailer_basics.html#sending-multipart-emails
+  # https://stackoverflow.com/a/15818886
+  def email_body
+    part_to_use = last_email.text_part || last_email.html_part || last_email
+
+    # return the message body without the header information
+    part_to_use.body.decoded
+  end
+end

--- a/config/initializers/last_email_observer.rb
+++ b/config/initializers/last_email_observer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class LastEmailObserver
+
+  def self.delivered_email(message)
+    LastEmailCache.instance.last_email = message
+  end
+
+end
+
+ActionMailer::Base.register_observer(LastEmailObserver)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,11 @@ Rails.application.routes.draw do
 
   get "/jobs/import", to: "jobs#import", as: :jobs_import
 
+  get "/last-email",
+      to: "last_email#show",
+      as: "last_email",
+      constraints: ->(_request) { ENV.fetch("ENABLE_LAST_EMAIL", "false") == "true" }
+
   root to: "transactions#index"
 
   match "/404", to: "errors#not_found", via: :all

--- a/spec/lib/last_email_cache_spec.rb
+++ b/spec/lib/last_email_cache_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LastEmailCache do
+  subject(:instance) { described_class.instance }
+
+  before(:each) { instance.reset }
+
+  let(:recipient) { "test@example.com" }
+  let(:add_attachment) { false }
+  let(:expected_keys) { %w[date from to bcc cc reply_to subject body attachments] }
+
+  describe "#last_email_json" do
+
+    context "when the no emails have been sent" do
+      let(:expected_keys) { %w[error] }
+
+      it "returns a JSON string" do
+        result = instance.last_email_json
+
+        expect(result).to be_a(String)
+        expect { JSON.parse(result) }.to_not raise_error
+      end
+
+      it "responds with an error message" do
+        result = JSON.parse(instance.last_email_json)
+
+        expect(result.keys).to match_array(expected_keys)
+      end
+    end
+
+    context "when a basic email is sent" do
+      context "and it is formatted as plain text" do
+        before(:each) { TestMailer.text_email(recipient).deliver_now }
+
+        it "returns a JSON string" do
+          result = instance.last_email_json
+          puts "result was #{result}"
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the email" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"].keys).to match_array(expected_keys)
+        end
+
+        it "extracts the plain text body content" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
+        end
+      end
+
+      context "and it is formatted as html" do
+        before(:each) { TestMailer.html_email(recipient).deliver_now }
+
+        it "returns a JSON string" do
+          result = instance.last_email_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the email" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"].keys).to match_array(expected_keys)
+        end
+
+        it "extracts the html body content" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"]["body"]).to start_with("<h1>This is the html version of an email</h1>")
+        end
+      end
+    end
+
+    # Multi-part essentially means the email contains more than 2 elements. An
+    # element can be a HTML version, and plain text version, and an
+    # attachment. If it contains at least 2 of these it will be sent as a
+    # multipart email
+    context "when a multi-part email is sent" do
+      context "and it contains both a html and text version" do
+        before(:each) { TestMailer.multipart_email(recipient).deliver_now }
+
+        it "returns a JSON string" do
+          result = instance.last_email_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the email" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"].keys).to match_array(expected_keys)
+        end
+
+        it "extracts the plain text body content" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
+        end
+      end
+    end
+
+    context "when multiple emails have been sent" do
+      before(:each) do
+        TestMailer.text_email(recipient).deliver_now
+        TestMailer.text_email(last_recipient).deliver_now
+      end
+
+      let(:last_recipient) { "joe.bloggs@example.com" }
+
+      it "returns a JSON string" do
+        result = instance.last_email_json
+
+        expect(result).to be_a(String)
+        expect { JSON.parse(result) }.to_not raise_error
+      end
+
+      it "contains the attributes of the email" do
+        result = JSON.parse(instance.last_email_json)
+
+        expect(result["last_email"].keys).to match_array(expected_keys)
+      end
+
+      it "extracts the plain text body content" do
+        result = JSON.parse(instance.last_email_json)
+
+        expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
+      end
+
+      it "contains the details of the last email sent" do
+        result = JSON.parse(instance.last_email_json)
+
+        expect(result["last_email"]["to"]).to eq([last_recipient])
+      end
+    end
+  end
+end

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "LastEmail", type: :request do
+  describe "/last-email" do
+    before(:each) {  stub_const("ENV", ENV.to_hash.merge("ENABLE_LAST_EMAIL" => enable_last_email)) }
+
+    context "when the env var ENABLE_LAST_EMAIL is 'true'" do
+      let(:enable_last_email) { "true" }
+
+      before(:each) { TestMailer.text_email("test@example.com").deliver_now }
+
+      it "returns the JSON value of the LastEmailCache" do
+        get last_email_path
+
+        expect(response.body).to eq(LastEmailCache.instance.last_email_json)
+        expect(LastEmailCache.instance.last_email_json).to include("test@example.com")
+      end
+    end
+
+    context "when the env var ENABLE_LAST_EMAIL is 'false'" do
+      let(:enable_last_email) { "false" }
+
+      it "cannot load the page" do
+        expect { get last_email_path }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "LastEmail", type: :request do
   describe "/last-email" do
-    before(:each) {  stub_const("ENV", ENV.to_hash.merge("ENABLE_LAST_EMAIL" => enable_last_email)) }
+    before(:each) { stub_const("ENV", ENV.to_hash.merge("ENABLE_LAST_EMAIL" => enable_last_email)) }
 
     context "when the env var ENABLE_LAST_EMAIL is 'true'" do
       let(:enable_last_email) { "true" }

--- a/spec/support/helpers/test_mailer.rb
+++ b/spec/support/helpers/test_mailer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class TestMailer < ActionMailer::Base
+
+  FROM_ADDRESS = "defra-ruby-email@example.com"
+
+  def multipart_email(recipient)
+    mail(
+      to: recipient,
+      from: FROM_ADDRESS,
+      subject: "Multi-part email"
+    ) do |format|
+      format.html { render html: "<h1>This is the html version of an email</h1>".html_safe }
+      format.text { render plain: "This is the text version of an email" }
+    end
+  end
+
+  def html_email(recipient)
+    mail(
+      to: recipient,
+      from: FROM_ADDRESS,
+      subject: "HTML email"
+    ) do |format|
+      format.html { render html: "<h1>This is the html version of an email</h1>".html_safe }
+    end
+  end
+
+  def text_email(recipient)
+    mail(
+      to: recipient,
+      from: FROM_ADDRESS,
+      subject: "Text email"
+    ) do |format|
+      format.text { render plain: "This is the text version of an email" }
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-279

Currently, when signing off the TCM for release we have to manually test anything related to the email functionality.

For example, the password reset function relies on sending a link in an email. This means we have to send the email to a real address to be able to access it to follow the link.

Adding the ability to read the last email to the TCM would mean we can automate the tests instead.

This is exactly what we did with the WCR, WEX and FRAE services which are also built using Rails and Ruby. In fact, we built a tool to make it possible for any Rails service to have this feature; [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email).

This change adds **defra-ruby-email** to the project so that we can access the last email sent in our acceptance tests.