### PR TITLE
Add non-UI endpoint to trigger file export process

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -9,6 +9,12 @@ class JobsController < ApplicationController
     render json: results.to_json, status: :ok
   end
 
+  def export
+    result = TransactionFileExportService.call
+
+    render json: result.results.to_json, status: :ok
+  end
+
   private
 
   def admin_only_check

--- a/app/services/transaction_file_export_service.rb
+++ b/app/services/transaction_file_export_service.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class TransactionFileExportService < ServiceObject
+  attr_reader :results
+
   def initialize(_params = {})
     super()
+
+    @results = { succeeded: [] }
   end
 
   def call
@@ -17,6 +21,7 @@ class TransactionFileExportService < ServiceObject
           transaction_file.user
         )
         exporter.generate_output_file(transaction_file)
+        @results[:succeeded].push(transaction_file.path)
         puts("Exported transaction file #{transaction_file.file_reference}")
       end
       @result = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   mount Coverband::Reporters::Web.new, at: "/coverage"
 
   get "/jobs/import", to: "jobs#import", as: :jobs_import
+  get "/jobs/export", to: "jobs#export", as: :jobs_export
 
   get "/last-email",
       to: "last_email#show",

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -51,4 +51,51 @@ RSpec.describe "Jobs", type: :request do
       end
     end
   end
+
+  describe "/jobs/export" do
+    let(:regime) { create(:regime) }
+    context "when a user is signed in" do
+      before do
+        sign_in(user)
+      end
+
+      context "and they are an admin" do
+        let(:user) { create(:user_with_regime, :admin, regime: regime) }
+        let(:results) do
+          {
+            succeeded: ["cfd/cfdai50001t.dat", "cfd/cfdai50002t.dat"]
+          }
+        end
+
+        before(:each) do
+          allow(TransactionFileExportService).to receive(:call) { results }
+        end
+
+        it "renders JSON containing the results and returns a 200 response" do
+          get jobs_export_path
+
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(results.to_json)
+        end
+      end
+
+      context "and they are not an admin" do
+        let(:user) { create(:user_with_regime, :billing, regime: regime) }
+
+        it "responds with an error" do
+          get jobs_export_path
+
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+
+    context "when a user is not signed in" do
+      subject { get jobs_export_path }
+
+      it "redirects to the sign in page" do
+        expect(subject).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -61,21 +61,19 @@ RSpec.describe "Jobs", type: :request do
 
       context "and they are an admin" do
         let(:user) { create(:user_with_regime, :admin, regime: regime) }
-        let(:results) do
-          {
-            succeeded: ["cfd/cfdai50001t.dat", "cfd/cfdai50002t.dat"]
-          }
+        let(:result) do
+          OpenStruct.new(results: { succeeded: ["cfd/cfdai50001t.dat", "cfd/cfdai50002t.dat"] })
         end
 
         before(:each) do
-          allow(TransactionFileExportService).to receive(:call) { results }
+          allow(TransactionFileExportService).to receive(:call) { result }
         end
 
         it "renders JSON containing the results and returns a 200 response" do
           get jobs_export_path
 
           expect(response).to have_http_status(200)
-          expect(response.body).to eq(results.to_json)
+          expect(response.body).to eq(result.results.to_json)
         end
       end
 

--- a/spec/services/transaction_file_export_service_spec.rb
+++ b/spec/services/transaction_file_export_service_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe TransactionFileExportService do
         expect(result.success?).to be(true)
         expect(result.failed?).to be(false)
       end
+
+      it "records details of the exported files in the results" do
+        result = service.call
+
+        expect(result.results[:succeeded]).to eq(["cfd/cfdai50001t.dat", "cfd/cfdai50002t.dat"])
+      end
     end
 
     context "when an error occurs" do
@@ -68,6 +74,12 @@ RSpec.describe TransactionFileExportService do
         expect(TcmLogger).to receive(:notify).with(error)
 
         service.call
+      end
+
+      it "returns no exported files in the results" do
+        result = service.call
+
+        expect(result.results[:succeeded]).to be_empty
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-287

To make testing the TCM easier we want to be able to trigger some tasks from our [sroc-acceptance-tests](https://github.com/DEFRA/sroc-acceptance-tests) that currently are done in the background using CRON.

For example, having processed some transactions and queued a transaction file for export if we can actually generate the file and upload it to the AWS S3 bucket from our tests we can then run other assertions to confirm the file exported as expected.

This change adds a new endpoint that when hit will trigger the file export process in the same way the CRON schedule does. There won't be any UI as it's expected to be used by the acceptance tests (though it also gives us the flexibility to trigger the job manually when needed!)