### PR TITLE
Add build Docker image Github Action to CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,75 @@
+name: DOCKER
+
+on:
+  push:
+    # Trigger this workflow on changes to `main`
+    branches: [ main ]
+    # Trigger this workflow if a semver tag is pushed
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Our main, default container registry
+  GHC_REGISTRY: ghcr.io
+  # github.repository will be <account>/<repo>, for example, DEFRA/sroc-tcm-admin
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones block `git describe --always --tags` from working later in 'Set all tags'
+
+      # Login against a GitHub Container registry
+      # https://github.com/docker/login-action
+      - name: Log into GH Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.GHC_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.GHC_REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # The combination of the original tags plus the sed calculated ones are combined and stored as a multiline string
+      # in a new env var.
+      #
+      # Some things to note
+      #  - each line of the HEREDOC must output something. That is why we call 'echo' in each one
+      #  - steps.meta.outputs.tags is itself a multiline string so we must wrap the call in quotes else the second line
+      #    of the string is interpreted as a command
+      #  - GitHub action's `set-output` truncates multiline strings which is why we have resorted to what you see below
+      #    to get a value which contains all the possible tags as a multiline string
+      #  - the 'if' determines if this is a push to `main` or a new tag. If a push to `main` we add a unique tag, for
+      #    example `v0.13.2-2-g9ce6d11`. This is to support testing
+      #
+      # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#multiline-strings
+      # https://github.community/t/set-output-truncates-multiline-strings/16852/8
+      - name: Set all tags
+        run: |
+          echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
+          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "ghcr.io/defra/sroc-tcm-admin:$(git describe --always --tags)"; fi >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          target: production
+          build-args: |
+            GIT_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            DOCKER_TAG=${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          push: true
+          labels: ${{ steps.meta_github.outputs.labels }}
+          tags: ${{ env.ALL_TAGS }}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-286

Now we are able to build a Docker image of the TCM we want to have our CI automatically build one when

- a change is made to `main`
- a new version [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) is pushed

On the [sroc-charging-module-api](https://github.com/DEFRA/sroc-charging-module-api) we have this ability. We use GitHub actions and store the built image in [GitHub Container Registry](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages).

This change adds the same functionality to this project using the Charging Module as a template.