### PR TITLE
Update Airbrake project key env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ARCHIVE_BUCKET=aws_s3_bucket_url_here
 
 # Airbrake/Errbit settings
 AIRBRAKE_HOST=https://my-errbit-instance.com
-AIRBRAKE_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
+AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Domains
 # Used as part of the email config for `default_url_options`

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -4,6 +4,6 @@ if defined?(Airbrake)
   Airbrake.configure do |config|
     config.host = ENV.fetch("AIRBRAKE_HOST")
     config.project_id = 1
-    config.project_key = ENV.fetch("AIRBRAKE_PROJECT_KEY")
+    config.project_key = ENV.fetch("AIRBRAKE_KEY")
   end
 end


### PR DESCRIPTION
Just a quick housekeeping change. When we started pulling together the task definition files for the TCM in preparation for deploying the TCM to AWS ECS we used the ones from the Charging Module API as a template. We spotted it using a slightly different name and decided we'd rename the env var for the TCM.

- this would save some effort in setting up the templates
- would bring some consistency across the 2 projects