### PR TITLE
Fix sonarcloud properties file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectName=sroc-tcm-admin
 sonar.links.homepage=https://github.com/DEFRA/sroc-tcm-admin
 sonar.links.ci=https://github.com/DEFRA/sroc-tcm-admin/actions
 sonar.links.scm=https://github.com/DEFRA/sroc-tcm-admin
-sonar.links.issue=https://github.com/DEFRA/sroc-service-team
+sonar.links.issue=https://github.com/DEFRA/sroc-service-team/issues
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on
 # Windows.
@@ -19,10 +19,11 @@ sonar.links.issue=https://github.com/DEFRA/sroc-service-team
 # simplecov, compare that to all files in the repo, and score 0 for all the
 # files we don't actually need to test. This severly deflates our scores and
 # means it is not consistent with our previous reporting tool CodeClimate.
-sonar.sources=./app,./config,./lib
+sonar.sources=./app,./lib
 sonar.tests=./test,./spec
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
 sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json


### PR DESCRIPTION
Over the last few PRs SonarCloud has been shouting at us because we keep making changes to config files and it can find no test coverage for it. This didn't follow our experience on other Rails-based projects so we did a quick comparison and found some inconsistencies in the files.

This change brings `sonar-project.properties` in line with those other projects.