### PR TITLE
Remove Coverband

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,6 @@ POSTGRES_DB=sroc-tcm-admin
 POSTGRES_USER=database_username_here
 POSTGRES_PASSWORD=database_password_here
 
-# Redis details
-REDIS_URL=redis://redis:6379
-
 # Email settings
 # In development, we use mailcatcher to intercept mail and view it at http://localhost:1080. See https://mailcatcher.me
 EMAIL_USERNAME=email_username_goes_here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,6 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      # Coverband, the gem we use to track production code usage depends on being able to connect to redis
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.2.0
-        with:
-          redis-version: 6
-
       - name: Database migrations
         run: |
           RAILS_ENV=test bundle exec rake db:migrate

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ gem "aws-sdk", "~> 2"
 # bootstrap 4
 gem "bootstrap", "~> 4.3.1"
 gem "bstard"
-# Measures production code usage
-gem "coverband"
 gem "devise"
 gem "devise_invitable"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,8 +109,6 @@ GEM
     childprocess (4.1.0)
     chronic (0.10.2)
     concurrent-ruby (1.1.9)
-    coverband (5.2.2)
-      redis (>= 3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -264,7 +262,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbtree3 (0.7.0)
-    redis (4.6.0)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -386,7 +383,6 @@ DEPENDENCIES
   byebug
   capybara
   capybara-selenium
-  coverband
   database_cleaner-active_record
   defra_ruby_style
   devise

--- a/README.md
+++ b/README.md
@@ -86,15 +86,6 @@ We also use [rubocop](https://github.com/rubocop/rubocop) to lint the code. To r
 
 - **🔎 LINT (TCM)**
 
-## Code usage
-
-To help us assess which parts of the code base are actually being used in production we have implemented [Coverband](https://github.com/danmayer/coverband).
-
-To check the current usage of a running instance go to `/coverage`. It is our intent to review the data in the near future to
-
-- confirm our suspicion there is redundant code in the project
-- to identify which classes and methods to target first for removal
-
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Make sure you already have:
 
 - [Ruby 2.7.1](https://www.ruby-lang.org/en/)
 - [PostgreSQL v12](https://www.postgresql.org/)
-- [Redis](https://redis.io/)
 
 ## Installation
 

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-Coverband.configure do |config|
-  # Experimental support for tracking view layer tracking.
-  # Does not track line-level usage, only indicates if an entire file
-  # is used or not.
-  config.track_views = true
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,6 @@ Rails.application.routes.draw do
     end
   end
 
-  mount Coverband::Reporters::Web.new, at: "/coverage"
-
   get "/jobs/import", to: "jobs#import", as: :jobs_import
   get "/jobs/export", to: "jobs#export", as: :jobs_export
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,6 @@ services:
       - "54321:5432"
     env_file:
       - .env
-  # The TCM uses https://github.com/danmayer/coverband to monitor code usage. We're trying to find dead/unused code
-  # which we can then delete. Coverband stores it's results in redis by default
-  redis:
-    image: redis
-    volumes:
-      - tcm_redis_volume:/data
-    ports:
-      - "63791:6379"
   # We use this locally to to allow us to easily access any emails sent and not worry about creating real email
   # accounts. When the environment is running go to http://localhost:1080 to access any emails sent
   mail:
@@ -60,4 +52,3 @@ services:
 
 volumes:
   tcm_db_volume:
-  tcm_redis_volume:


### PR DESCRIPTION
5 months ago we [Add coverband support to the project](https://github.com/DEFRA/sroc-tcm-admin/pull/479). The intent was to learn what features what not being used by users. We could then look to start reducing the amount of code we are currently maintaining. The hope is this would lead to improved unit test coverage.

We ideally would have got a release out sooner but we are due to get one out on 9 March 2022. In the meantime, we are working on migrating the project to a brand new AWS ECS environment. We've decided that there is no point in increasing the complexity of that work by requiring Redis to also be part of the new environments. Coverband depends on it so it's still needed for our release to our EC2 environment on 9 March. We believe between 9 March and the new ECS environment going live there will be plenty of time to generate and see the Coverband metrics, especially as we are heading into annual billing (a once a year event).

But we won't need it after that so we're taking the opportunity to scrub it from the project now.