### PR TITLE
Fix missing keys() method in form_error_helper

### DIFF
--- a/app/helpers/form_error_helper.rb
+++ b/app/helpers/form_error_helper.rb
@@ -14,7 +14,7 @@ module FormErrorHelper
 
   def error_list(resource)
     el = []
-    resource.errors.keys.sort.each do |k|
+    resource.errors.messages.sort.to_h.keys.each do |k|
       resource.errors.full_messages_for(k).each do |message|
         el << error_item(k, message)
       end

--- a/app/helpers/form_error_helper.rb
+++ b/app/helpers/form_error_helper.rb
@@ -14,7 +14,7 @@ module FormErrorHelper
 
   def error_list(resource)
     el = []
-    resource.errors.messages.sort.to_h.keys.each do |k|
+    resource.errors.messages.sort.to_h.each_key do |k|
       resource.errors.full_messages_for(k).each do |message|
         el << error_item(k, message)
       end


### PR DESCRIPTION
We spotted we were seeing an Nginx 404 when working with the TCM in the AWS environments. Locally, whenever something went wrong we'd get a message about `keys()` does not exist.

```
E, [2022-03-09T10:44:03.291715 #2788] ERROR -- : [b7f68b30-d46d-430c-b841-55704f8860b5] undefined method `keys' for #<ActiveModel::Errors:0x0000564c83b58fd0>
Did you mean?  key?
F, [2022-03-09T10:44:03.310856 #2788] FATAL -- : [b7f68b30-d46d-430c-b841-55704f8860b5]
[b7f68b30-d46d-430c-b841-55704f8860b5] ActionView::Template::Error (undefined method `keys' for #<ActiveModel::Errors:0x0000564c83b58fd0>
Did you mean?  key?):
[b7f68b30-d46d-430c-b841-55704f8860b5]     3:     <div id="error_explanation" class="alert error-banner" role="alert">
[b7f68b30-d46d-430c-b841-55704f8860b5]     4:       <h2 class="heading-medium"><%= title %></h2>
[b7f68b30-d46d-430c-b841-55704f8860b5]     5:       <p><%= description %></p>
[b7f68b30-d46d-430c-b841-55704f8860b5]     6:       <%= error_list(resource) %>
[b7f68b30-d46d-430c-b841-55704f8860b5]     7:     </div>
[b7f68b30-d46d-430c-b841-55704f8860b5]     8:   </div>
[b7f68b30-d46d-430c-b841-55704f8860b5]     9: </div>
[b7f68b30-d46d-430c-b841-55704f8860b5]
[b7f68b30-d46d-430c-b841-55704f8860b5] app/helpers/form_error_helper.rb:17:in `error_list'
[b7f68b30-d46d-430c-b841-55704f8860b5] app/views/shared/_error_header.html.erb:6
[b7f68b30-d46d-430c-b841-55704f8860b5] app/helpers/form_error_helper.rb:12:in `error_header'
[b7f68b30-d46d-430c-b841-55704f8860b5] app/views/permit_categories/_form.html.erb:4
[b7f68b30-d46d-430c-b841-55704f8860b5] app/views/permit_categories/_form.html.erb:1
[b7f68b30-d46d-430c-b841-55704f8860b5] app/views/permit_categories/new.html.erb:6
[b7f68b30-d46d-430c-b841-55704f8860b5] app/controllers/permit_categories_controller.rb:110:in `block (2 levels) in create'
[b7f68b30-d46d-430c-b841-55704f8860b5] app/controllers/permit_categories_controller.rb:101:in `create'
[b7f68b30-d46d-430c-b841-55704f8860b5] app/controllers/application_controller.rb:38:in `set_local_time'
```

The line it didn't like was in `app/helpers/form_error_helper.rb`

```ruby
def error_list(resource)
  el = []
  resource.errors.keys.sort.each do |k| # <- THIS ONE!
    resource.errors.full_messages_for(k).each do |message|
      el << error_item(k, message)
    end
  end
  content_tag(:ul, class: "error-summary-list list-unstyled") do
    safe_join(el, "\n")
  end
end
```

It took some investigation but we tracked it down to a change in Rails `ActiveModel::Errors` class. In [Rails 6](https://api.rubyonrails.org/v6.1.3/classes/ActiveModel/Errors.html#method-i-keys) the method `keys()` exists. In [Rails 7](https://api.rubyonrails.org/v7.0.2.3/classes/ActiveModel/Errors.html) its gone.

Yet again, we're affected by the TCM's poor unit test coverage. Something that should have been caught when the gem was updated has got through and only now been spotted.

The helper appears to be trying to replicate the types of errors you'll see on GOV.UK sites. So, rather than just show the first error that comes to hand, it is showing all errors, for example, when validating a new object. It also wants to group them by the attributes when it displays the message to the user.

There are probably better ways of doing what the helper is trying to achieve, for example, [group_by_attribute()](https://api.rubyonrails.org/v7.0.2.3/classes/ActiveModel/Errors.html#method-i-group_by_attribute) looks like it could replace a bunch of the logic. But we've sought to apply a fix that requires the least amount of changes at this time to something with no unit test coverage.

Our solution is that [messages()](https://api.rubyonrails.org/v7.0.2.3/classes/ActiveModel/Errors.html#method-i-messages) returns a hash of `{attr: :message}` for all the errors. Ruby allows you to just call `sort()` on a hash like this but that returns an array. So, next, we call `to_h()` to get back to a hash and all hash instances have a `keys()` method.

This gets us back to what the helper was expecting and the rest of the logic works again.