### PR TITLE
Add test-only reset DB endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ PAS_RULESET='Installations_RuleSet'
 
 # Test user password when seeding and running acceptance tests
 DEFAULT_PASSWORD=default_password_goes_here
+# Enable the /last-email test endpoint
+ENABLE_LAST_EMAIL=true
 
 # Google Analytics
 GTM_CODE=gtm_code_goes_here

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ PAS_RULESET='Installations_RuleSet'
 DEFAULT_PASSWORD=default_password_goes_here
 # Enable the /last-email test endpoint
 ENABLE_LAST_EMAIL=true
+# Tell the the app what environment we are running in, for example, pre-production. This is different to the 'type' of environment which RAILS_ENV is used for.
+# Used to determine if non-production functionality can be enabled, for example, cleaning the DB
+TCM_ENVIRONMENT=local
 
 # Google Analytics
 GTM_CODE=gtm_code_goes_here

--- a/app/controllers/clean_controller.rb
+++ b/app/controllers/clean_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CleanController < ActionController::Base
+  def show
+    result = CleanDbService.call
+
+    render json: result.results.to_json, status: :ok
+  end
+end

--- a/app/services/clean_db_service.rb
+++ b/app/services/clean_db_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class CleanDbService < ServiceObject
+  attr_reader :results
+
+  def initialize(_params = {})
+    super()
+
+    @results = { succeeded: [] }
+  end
+
+  def call
+    clean_tables
+    reset_counters
+    @result = true
+
+    self
+  rescue StandardError => e
+    @result = false
+    Rails.logger.error("Could not clean the db: #{e.message}")
+
+    self
+  end
+
+  private
+
+  def clean_tables
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if do_not_touch_tables.include?(table)
+
+      ActiveRecord::Base.connection.execute("TRUNCATE #{table} CASCADE")
+      @results[:succeeded].push(table)
+    end
+  end
+
+  def reset_counters
+    ActiveRecord::Base.connection.execute("UPDATE sequence_counters SET file_number=50001, invoice_number=1")
+  end
+
+  def do_not_touch_tables
+    @do_not_touch_tables ||= %w[
+      ar_internal_metadata
+      exclusion_reasons
+      permit_categories
+      regime_users
+      regimes
+      schema_migrations
+      sequence_counters
+      sequence_counters
+      users
+    ]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,11 @@ Rails.application.routes.draw do
       as: "last_email",
       constraints: ->(_request) { ENV.fetch("ENABLE_LAST_EMAIL", "false") == "true" }
 
+  get "/clean",
+      to: "clean#show",
+      as: "clean",
+      constraints: ->(_request) { ENV.fetch("TCM_ENVIRONMENT", "production") != "production" }
+
   root to: "transactions#index"
 
   match "/404", to: "errors#not_found", via: :all

--- a/spec/requests/clean_spec.rb
+++ b/spec/requests/clean_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Clean", type: :request do
+  describe "/clean" do
+    before(:each) { stub_const("ENV", ENV.to_hash.merge("TCM_ENVIRONMENT" => tcm_environment)) }
+
+    context "when the env var TCM_ENVIRONMENT is not 'production'" do
+      let(:tcm_environment) { "development" }
+      let(:result) do
+        double("CleanDbService", results: { succeeded: %w[table_1 table_2] })
+      end
+
+      before(:each) { allow(CleanDbService).to receive(:call) { result } }
+
+      it "returns a list of tables that have been truncated successfully" do
+        get clean_path
+
+        expect(CleanDbService).to have_received(:call).exactly(1).times
+        expect(response.body).to eq(result.results.to_json)
+      end
+    end
+
+    context "when the env var TCM_ENVIRONMENT is 'production'" do
+      let(:tcm_environment) { "production" }
+
+      it "cannot load the page" do
+        expect { get clean_path }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/services/clean_db_service_spec.rb
+++ b/spec/services/clean_db_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CleanDbService do
+  describe "#call" do
+    context "when no error is thrown" do
+      let(:connection) do
+        double(
+          "connection",
+          tables: %w[schema_migrations table_1 table_2],
+          execute: true
+        )
+      end
+
+      before(:each) do
+        allow(ActiveRecord::Base).to receive(:connection) { connection }
+      end
+
+      it "marks the clean as successful" do
+        result = described_class.call
+
+        expect(result.success?).to be(true)
+        expect(result.failed?).to be(false)
+      end
+
+      it "only cleans certain tables" do
+        result = described_class.call
+
+        expect(result.results[:succeeded]).to eq(%w[table_1 table_2])
+      end
+    end
+
+    context "when an error is thrown" do
+      before(:each) do
+        allow(ActiveRecord::Base).to receive(:connection).and_raise("boom")
+      end
+
+      it "marks the clean as failed" do
+        result = described_class.call
+
+        expect(result.success?).to be(false)
+        expect(result.failed?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-281

The nature of the TCM is that it gets its data from import files. It's not data added through the UI by user interaction. This means we rely on fixed fixture files we drop into AWS S3 buckets that the TCM then grabs and imports.

This means the data in our test files is very static. Added to that once a file has been imported the data in it can't be imported again. So, in order to build repeatable tests that don't become super-complex, we've worked on the basis that each test run starts with a _clean_ DB. The process of cleaning is currently done via `rake db:reset && rake db:seed` triggered through Jenkins. But this needs to be done manually. We really need to be able to trigger the reset from our test suite [sroc-acceptance-tests](https://github.com/DEFRA/sroc-acceptance-tests). That way we can just keep re-running tests with no manual intervention.

So, this change adds an endpoint that will clean the DB of existing data. It will only be accessible in our non-production environments. We avoid using the `rake db:reset` as that drops the DB and recreates it and our experience has found that then forces you to deal with trying to kill active DB connections.

Instead, we drop down an abstraction and use `ActiveRecord::Base` to make direct calls to specific tables to truncate them ready for reuse.