### PR TITLE
Use TCM_ENVIRONMENT for all test endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,10 +43,11 @@ PAS_RULESET='Installations_RuleSet'
 
 # Test user password when seeding and running acceptance tests
 DEFAULT_PASSWORD=default_password_goes_here
-# Enable the /last-email test endpoint
-ENABLE_LAST_EMAIL=true
+
 # Tell the the app what environment we are running in, for example, pre-production. This is different to the 'type' of environment which RAILS_ENV is used for.
-# Used to determine if non-production functionality can be enabled, for example, cleaning the DB
+# Used to determine if non-production test support features can be enabled
+# - clean the DB endpoint at `/clean`
+# - read the last email sent at `/last-email
 TCM_ENVIRONMENT=local
 
 # Google Analytics

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ We also use [rubocop](https://github.com/rubocop/rubocop) to lint the code. To r
 
 - **🔎 LINT (TCM)**
 
+### Test support endpoints
+
+The app includes endpoints that support our [acceptance tests](https://github.com/DEFRA/sroc-acceptance-tests). They are split between those that are only enabled in our non-production environments and those that can be accessed but you must be an admin. All respond in JSON format.
+
+#### Non-production only
+
+Either because they are distructive or sensitive these endpoints are only available in non-production environments.
+
+> We are referring to when running it locally or in our development, test or pre-production environments. This is different to the Rails environment specified by `RAILS_ENV`.
+
+- `/clean` Will reset most tables in the database. This means, for example, removing all transaction data and resetting the sequence counters. Seeded data, for example, regimes, permit categories and users are retained. We use it to automate resetting the DB for running some of our acceptance tests
+- `/last-email` Will return the details and content of the last email sent from the app. We use it to allow us to automate checking the content of emails sent from the system and completing journeys that require following a link provided in an email
+
+#### Admin only
+
+Though built to support testing these endpoints are available in production but only by those with the `admin`. There may be times it would be helpful to peform these tasks outside of a test setting.
+
+- `/jobs/import` trigger the transaction file import process
+- `/jobs/export` trigger the transaction file export process
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   get "/last-email",
       to: "last_email#show",
       as: "last_email",
-      constraints: ->(_request) { ENV.fetch("ENABLE_LAST_EMAIL", "false") == "true" }
+      constraints: ->(_request) { ENV.fetch("TCM_ENVIRONMENT", "production") != "production" }
 
   get "/clean",
       to: "clean#show",

--- a/spec/requests/clean_spec.rb
+++ b/spec/requests/clean_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Clean", type: :request do
     before(:each) { stub_const("ENV", ENV.to_hash.merge("TCM_ENVIRONMENT" => tcm_environment)) }
 
     context "when the env var TCM_ENVIRONMENT is not 'production'" do
-      let(:tcm_environment) { "development" }
+      let(:tcm_environment) { "local" }
       let(:result) do
         double("CleanDbService", results: { succeeded: %w[table_1 table_2] })
       end

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 RSpec.describe "LastEmail", type: :request do
   describe "/last-email" do
-    before(:each) { stub_const("ENV", ENV.to_hash.merge("ENABLE_LAST_EMAIL" => enable_last_email)) }
+    before(:each) { stub_const("ENV", ENV.to_hash.merge("TCM_ENVIRONMENT" => tcm_environment)) }
 
-    context "when the env var ENABLE_LAST_EMAIL is 'true'" do
-      let(:enable_last_email) { "true" }
+    context "when the env var TCM_ENVIRONMENT is not 'production'" do
+      let(:tcm_environment) { "local" }
 
       before(:each) { TestMailer.text_email("test@example.com").deliver_now }
 
@@ -19,8 +19,8 @@ RSpec.describe "LastEmail", type: :request do
       end
     end
 
-    context "when the env var ENABLE_LAST_EMAIL is 'false'" do
-      let(:enable_last_email) { "false" }
+    context "when the env var TCM_ENVIRONMENT is 'production'" do
+      let(:tcm_environment) { "production" }
 
       it "cannot load the page" do
         expect { get last_email_path }.to raise_error(ActionController::RoutingError)


### PR DESCRIPTION
[Add ability to read last email for testing](https://github.com/DEFRA/sroc-tcm-admin/pull/533) and [Add test-only reset DB endpoint](https://github.com/DEFRA/sroc-tcm-admin/pull/544) added endpoints that are only to be used to support testing in our non-production environments.

In PR #533 we used the env var `ENABLE_LAST_EMAIL` to determine if the function should be enabled i.e. we're in a non-production environment. We were all set to do the same for resetting the DB but instead went for something that explicitly tells the TCM what environment it's in.

Going forward, we can use this one env var to control all our test support rather than having an env var for each. We can also (if we find the time!) add the value to our Airbrake errors. That way we know exactly what non-production environment an error originated in.