### PR TITLE
Fix broken accept invitation view

### DIFF
--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,35 @@
+<div class="row">
+  <div class="col-8">
+    <h1><%= t 'devise.invitations.edit.header' %></h1>
+  </div>
+</div>
+<%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
+  <%= error_header(resource) %>
+  <%= f.hidden_field :invitation_token %>
+  <% if f.object.class.require_password_on_accepting %>
+    <%= render partial: 'shared/password_help' %>
+    <div class="row">
+      <div class="col-lg-6">
+        <div class="form-group">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: 'form-control' %>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-6">
+        <div class="form-group">
+          <%= f.label :password_confirmation %>
+          <%= f.password_field :password_confirmation, class: 'form-control' %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="row mt-4 mb-4">
+    <div class="col-lg-6 actions">
+      <%= f.submit t("devise.invitations.edit.submit_button"),
+        class: "btn btn-primary" %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
In [PR #546](https://github.com/DEFRA/sroc-tcm-admin/pull/546) as part of implementing GOV.UK Notify for emails we removed the Devise mailer views that were no longer being used. Whilst we were at it we also removed the unused Devise views. Turns out not all of those views were unused! 🤦

This change adds back in the views we actually depend on.