### PR TITLE
Seed additional test data

### DIFF
--- a/app/services/clean_db_service.rb
+++ b/app/services/clean_db_service.rb
@@ -39,7 +39,9 @@ class CleanDbService < ServiceObject
 
   def do_not_touch_tables
     @do_not_touch_tables ||= %w[
+      annual_billing_data_files
       ar_internal_metadata
+      data_upload_errors
       exclusion_reasons
       permit_categories
       regime_users

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,6 +32,37 @@ def seed_users
   end
 end
 
+def create_annual_billing_data_file(details)
+  data_file = AnnualBillingDataFile.new(
+    regime_id: details["regime_id"],
+    filename: details["filename"],
+    status: details["status"],
+    success_count: details["success_count"],
+    failed_count: details["failed_count"],
+    created_at: details["created_at"],
+    updated_at: details["updated_at"]
+  )
+  data_file.save!
+
+  details["data_upload_errors"].each do |detail|
+    data_upload_error = DataUploadError.new(
+      line_number: detail["line_number"],
+      message: detail["message"]
+    )
+    data_upload_error.annual_billing_data_file = data_file
+    data_upload_error.save!
+  end
+end
+
+def seed_annual_billing_data_files
+  seeds = JSON.parse(File.read("#{Rails.root}/db/seeds/annual_billing_data_files.json"))
+  data_files = seeds["annual_billing_data_files"]
+
+  data_files.each do |data_file|
+    create_annual_billing_data_file(data_file) unless AnnualBillingDataFile.where(filename: data_file["filename"]).exists?
+  end
+end
+
 if Regime.count.zero?
   Regime.create!(name: "PAS", title: "Installations")
   Regime.create!(name: "CFD", title: "Water Quality")
@@ -46,6 +77,7 @@ Regime.all.each do |r|
 end
 
 seed_users
+seed_annual_billing_data_files
 
 r = Regime.find_by!(slug: "pas")
 r.permit_categories.destroy_all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,7 +59,9 @@ def seed_annual_billing_data_files
   data_files = seeds["annual_billing_data_files"]
 
   data_files.each do |data_file|
-    create_annual_billing_data_file(data_file) unless AnnualBillingDataFile.where(filename: data_file["filename"]).exists?
+    unless AnnualBillingDataFile.where(filename: data_file["filename"]).exists?
+      create_annual_billing_data_file(data_file)
+    end
   end
 end
 

--- a/db/seeds/annual_billing_data_files.json
+++ b/db/seeds/annual_billing_data_files.json
@@ -1,0 +1,91 @@
+{
+  "annual_billing_data_files": [
+    {
+      "regime_id": 1,
+      "filename": "pas/20180618092120/NW_PAS_100518.csv",
+      "status": "completed",
+      "success_count": 5,
+      "failed_count": 0,
+      "created_at": "2018-06-18T08:21:20.511Z",
+      "updated_at": "2018-06-18T08:24:11.111Z",
+      "data_upload_errors": []
+    },
+    {
+      "regime_id": 1,
+      "filename": "pas/20180618092758/NE_PAS_CSV_10518.csv",
+      "status": "completed",
+      "success_count": 5,
+      "failed_count": 2,
+      "created_at": "2018-06-18T08:27:58.511Z",
+      "updated_at": "2018-06-18T08:31:19.111Z",
+      "data_upload_errors": [
+        {
+          "line_number": 2,
+          "message": "Could not find Permit reference matching 'AB1234YZ'"
+        },
+        {
+          "line_number": 5,
+          "message": "Invalid Permit category value: '2.12.15'"
+        }
+      ]
+    },
+    {
+      "regime_id": 2,
+      "filename": "cfd/20180622151414/CfD Annual Billing data noPV 180622-1512.csv",
+      "status": "completed",
+      "success_count": 5,
+      "failed_count": 0,
+      "created_at": "2018-06-22T14:14:14.511Z",
+      "updated_at": "2018-06-22T14:14:34.111Z",
+      "data_upload_errors": []
+    },
+    {
+      "regime_id": 2,
+      "filename": "cfd/20180606145458/CfD Annual Billing data noPV 180606-1554.csv",
+      "status": "completed",
+      "success_count": 5,
+      "failed_count": 2,
+      "created_at": "2018-06-06T14:54:58.511Z",
+      "updated_at": "2018-06-06T15:00:24.111Z",
+      "data_upload_errors": [
+        {
+          "line_number": 2,
+          "message": "Could not find Permit reference matching 'AB1234YZ'"
+        },
+        {
+          "line_number": 5,
+          "message": "Invalid Permit category value: '2.12.15'"
+        }
+      ]
+    },
+    {
+      "regime_id": 3,
+      "filename": "wml/20180817113803/NE_ClosedLF_070818_PM.csv",
+      "status": "completed",
+      "success_count": 5,
+      "failed_count": 0,
+      "created_at": "2018-08-17T10:38:03.511Z",
+      "updated_at": "2018-08-17T10:39:12.111Z",
+      "data_upload_errors": []
+    },
+    {
+      "regime_id": 3,
+      "filename": "wml/20180817111315/NW_ClosedLF_070818_PM.csv",
+      "status": "completed",
+      "success_count": 5,
+      "failed_count": 2,
+      "created_at": "2018-08-17T10:13:15.511Z",
+      "updated_at": "2018-08-17T10:14:00.111Z",
+      "data_upload_errors": [
+        {
+          "line_number": 2,
+          "message": "Could not find Permit reference matching 'AB1234YZ'"
+        },
+        {
+          "line_number": 5,
+          "message": "Invalid Permit category value: '2.12.15'"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We're doing work on the [sroc-acceptance-tests](https://github.com/DEFRA/sroc-acceptance-tests) to make them repeatable and remove any need for human interaction. One of the blockers is that we need to be able to set the database to a known state for each test run. We've built features into the TCM to support this ([Add test-only reset DB endpoint](https://github.com/DEFRA/sroc-tcm-admin/pull/544), [Add non-UI endpoint to trigger file import process](https://github.com/DEFRA/sroc-tcm-admin/pull/467), [Add non-UI endpoint to trigger file export process](https://github.com/DEFRA/sroc-tcm-admin/pull/534)) but there are still some tests we can't run because of missing data.

One of these is the annual billing functionality. This is a feature that was built for Go live to import billing data directly into the service. It was a one time use thing that could be removed. It was agreed with the business the ability to still review the results needed to be retained but we could [Remove Annual billing upload functionality](https://github.com/DEFRA/sroc-tcm-admin/pull/416).

So, for testing, we have a feature that depends on data being present to use but no way to get it into the system. This is one example of test data we need to be able to seed the TCM with.