### PR TITLE
Fix Docker broken by missing Notify key

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify_mail
-  config.action_mailer.notify_mail_settings = { api_key: ENV.fetch("NOTIFY_API_KEY") }
+  config.action_mailer.notify_mail_settings = { api_key: ENV["NOTIFY_API_KEY"] }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,5 +66,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: ENV["DEFAULT_URL_HOST"] }
   config.action_mailer.delivery_method = :notify_mail
-  config.action_mailer.notify_mail_settings = { api_key: ENV.fetch("NOTIFY_API_KEY") }
+  config.action_mailer.notify_mail_settings = { api_key: ENV["NOTIFY_API_KEY"] }
 end


### PR DESCRIPTION
We didn't spot that [PR #546](https://github.com/DEFRA/sroc-tcm-admin/pull/546) broke our Docker workflow. Because we has used `ENV.fetch()` to grab the env var but then hadn't set it we were getting an exception thrown. Where we don't have a default but we are fine with `nil` we should be using `ENV[]` to grab the value. That won't error if the env var cannot be found.