### PR TITLE
Fix missing export data file after clean

### DIFF
--- a/app/services/clean_db_service.rb
+++ b/app/services/clean_db_service.rb
@@ -43,6 +43,7 @@ class CleanDbService < ServiceObject
       ar_internal_metadata
       data_upload_errors
       exclusion_reasons
+      export_data_files
       permit_categories
       regime_users
       regimes


### PR DESCRIPTION
In [PR #544](https://github.com/DEFRA/sroc-tcm-admin/pull/544) we added an endpoint to support our acceptance tests. It would clean out any transactional data and leave only lookup data, for example, regimes or original seeded data such as users.

When re-running our legacy tests in [sroc-acceptance-tests](https://github.com/DEFRA/sroc-acceptance-tests) we found an error was being thrown in the `Download Transaction Data` screen.

When looking at the logic in the view we found that it always assumes that a regime will have an `ExportDataFile` record though it might not be fully populated.

After review, we now understand the TCM has been built on the assumption that the `export_data_files` table will always have a record for each regime. It was seeded at Go Live and from then the records just get updated.

So, we need to update our clean logic to ensure this table does not get emptied.