### PR TITLE
Fix broken change password view

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,50 @@
+<div class="row mt-4 mb-4">
+  <div class="col">
+    <h1>Change your password</h1>
+  </div>
+</div>
+
+<%= form_for(resource, as: resource_name, url: user_registration_path, html: { method: :patch }) do |f| %>
+  <%= error_header(resource) %>
+
+  <%= render partial: 'shared/password_help' %>
+  <div class="row">
+    <div class="col-lg-6">
+      <div class="form-group">
+        <%= f.label :current_password, "Current password" %>
+        <%= f.password_field :current_password, autofocus: true, autocomplete: "off", class: "form-control" %>
+        <i>(we need your current password to confirm your changes)</i>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-6">
+      <div class="form-group">
+        <%= f.label :password, "New password" %>
+        <% if @minimum_password_length %>
+          <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <% end %>
+        <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-6">
+      <div class="form-group">
+        <%= f.label :password_confirmation, "Confirm new password" %>
+        <%= f.password_field :password_confirmation, autocomplete: "off",
+            class: "form-control" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row mt-2 mb-4">
+    <div class="col-lg-6 actions">
+      <%= f.submit "Change my password", class: "btn btn-primary" %>
+      <%= link_to "Cancel", root_path, class: "btn btn-secondary" %>
+    </div>
+  </div>
+<% end %>
+
+<%#= render "devise/shared/links" %>


### PR DESCRIPTION
In [PR #546](https://github.com/DEFRA/sroc-tcm-admin/pull/546) as part of implementing GOV.UK Notify for emails we removed the Devise mailer views that were no longer being used. Whilst we were at it we also removed the unused Devise views. Turns out not all of those views were unused! 🤦

This change adds back in the edit registration view which we must have amended in the past to be our change password view.