### PR TITLE
Add non-UI endpoint to trigger data export process

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -15,6 +15,12 @@ class JobsController < ApplicationController
     render json: result.results.to_json, status: :ok
   end
 
+  def data
+    result = DataExportService.call
+
+    render json: result.results.to_json, status: :ok
+  end
+
   private
 
   def admin_only_check

--- a/app/services/data_export_service.rb
+++ b/app/services/data_export_service.rb
@@ -21,14 +21,14 @@ class DataExportService < ServiceObject
         puts("Processing regime #{regime.name}")
         result = ExportTransactionDataService.call(regime: regime)
         if result.failed?
-          recordFailure(result, "Failed to export transactions for #{regime.name}")
+          record_failure(result, "Failed to export transactions for #{regime.name}")
         else
           # store file
           result = PutDataExportFileService.call(filename: result.filename)
           if result.failed?
-            recordFailure(result, "Failed to store export data file for #{regime.name}")
+            record_failure(result, "Failed to store export data file for #{regime.name}")
           else
-            recordSuccess(result)
+            record_success(result)
           end
         end
       end
@@ -50,16 +50,16 @@ def regimes(regime)
   Regime.all
 end
 
-def recordFailure(result, message)
+def record_failure(result, message)
   TcmLogger.error(message)
-  @results[:failed].push(filenameOnly(result.filename))
+  @results[:failed].push(filename_only(result.filename))
 end
 
-def recordSuccess(result)
-  @results[:succeeded].push(filenameOnly(result.filename))
+def record_success(result)
+  @results[:succeeded].push(filename_only(result.filename))
 end
 
-def filenameOnly(filename)
+def filename_only(filename)
   return "" unless filename
 
   File.basename(filename)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
 
   get "/jobs/import", to: "jobs#import", as: :jobs_import
   get "/jobs/export", to: "jobs#export", as: :jobs_export
+  get "/jobs/data", to: "jobs#data", as: :jobs_data
 
   get "/last-email",
       to: "last_email#show",

--- a/spec/requests/jobs_spec.rb
+++ b/spec/requests/jobs_spec.rb
@@ -96,4 +96,55 @@ RSpec.describe "Jobs", type: :request do
       end
     end
   end
+
+  describe "/jobs/data" do
+    let(:regime) { create(:regime) }
+    context "when a user is signed in" do
+      before do
+        sign_in(user)
+      end
+
+      context "and they are an admin" do
+        let(:user) { create(:user_with_regime, :admin, regime: regime) }
+        let(:result) do
+          results = {
+            results: {
+              succeeded: ["pas_transactions.csv.gz", "cfd_transactions.csv.gz", "wml_transactions.csv.gz"],
+              failed: []
+            }
+          }
+          OpenStruct.new(results)
+        end
+
+        before(:each) do
+          allow(DataExportService).to receive(:call) { result }
+        end
+
+        it "renders JSON containing the results and returns a 200 response" do
+          get jobs_data_path
+
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(result.results.to_json)
+        end
+      end
+
+      context "and they are not an admin" do
+        let(:user) { create(:user_with_regime, :billing, regime: regime) }
+
+        it "responds with an error" do
+          get jobs_data_path
+
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+
+    context "when a user is not signed in" do
+      subject { get jobs_data_path }
+
+      it "redirects to the sign in page" do
+        expect(subject).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-299

To make testing the TCM easier we want to be able to trigger some tasks from our [sroc-acceptance-tests](https://github.com/DEFRA/sroc-acceptance-tests) that currently are done in the background using CRON.

For example, having loaded the system with test data if we can generate the data export file and upload it to the AWS S3 bucket from our tests we can then run assertions to confirm the data export is working as expected.

This change adds a new endpoint that when hit will trigger the data export process in the same way the CRON schedule does. There won't be any UI as it's expected to be used by the acceptance tests (though it also gives us the flexibility to trigger the job manually when needed!)