### PR TITLE
Reset exported_data_files table during clean

### DIFF
--- a/app/services/clean_db_service.rb
+++ b/app/services/clean_db_service.rb
@@ -12,6 +12,7 @@ class CleanDbService < ServiceObject
   def call
     clean_tables
     reset_counters
+    reset_exported_data_files
     @result = true
 
     self
@@ -35,6 +36,16 @@ class CleanDbService < ServiceObject
 
   def reset_counters
     ActiveRecord::Base.connection.execute("UPDATE sequence_counters SET file_number=50001, invoice_number=1")
+  end
+
+  def reset_exported_data_files
+    ActiveRecord::Base.connection.execute(
+      "UPDATE export_data_files SET"\
+      " last_exported_at = NULL,"\
+      " status = 0,"\
+      " exported_filename = NULL,"\
+      " exported_filename_hash = NULL"
+    )
   end
 
   def do_not_touch_tables


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-299

We just [added non-UI endpoint to trigger data export process](https://github.com/DEFRA/sroc-tcm-admin/pull/569). This is part of our ongoing support for automating our testing.

We also a while back [added test-only reset DB endpoint](https://github.com/DEFRA/sroc-tcm-admin/pull/544) as part of this effort. We initially cleaned everything in the `exported_data_files` table but quickly found this caused an error (fixed in [Fix missing export data file after clean](https://github.com/DEFRA/sroc-tcm-admin/pull/550)).

The fix was to exclude the table from the clean. What we've now realised is we need to keep the records in the table as they remain static as one row for each regime (3 in total). But to truly reset the DB we need to reset some of the values in this table. We will then be returning the DB to a state where it appears the data export has not yet run.