### PR TITLE
Fix issue with missing pids/ folder for puma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /log/*
 !/log/.keep
 /tmp/*
-!/tmp/.keep
+!/tmp/pids/.keep
 .DS_Store
 *.log
 .svn


### PR DESCRIPTION
When you start the service using `bundle exec rails s`, **rails** will automatically create the folder `tmp/pids` as part of it's initialisation if it doesn't already exist.

[puma](https://github.com/puma/puma), the web server Rails uses and which you're advised to run directly in `production` doesn't do this and requires the folder to already exist.

Locally, as we have been working on the Docker version this didn't come to light, because we first ran it up with `development` as the target, which creates `tmp/pids`. Then any testing using `production` as the target would take advantage of the folder created.

This change ensures it will run with the target set to `production` (the default) in a fresh environment. `tmp/` was already part of the solution. We now create a `pids/` folder in there and move our `.keep` file into it.