### PR TITLE
Fix issue with missing pids/ folder (again!)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 !Gemfile
 !Gemfile.lock
 !Rakefile
+!tmp
 
 # re-ignore (!!) these files. Doing it this way means we avoid having to breakdown our entries above. For example, to
 # exclude app/assets the alternate would be to specify `!app/controllers, !app/helpers` etc above. This is less flexible

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /log/*
 !/log/.keep
 /tmp/*
+/tmp/pids/*
+!/tmp/.keep
+!/tmp/pids
 !/tmp/pids/.keep
 .DS_Store
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,6 +185,11 @@ COPY --from=asset_builder /usr/src/app/public ./public
 # This should be set in the project but just in case we ensure entrypoint.sh is executable
 RUN chmod +x entrypoint.sh
 
+# Ensure our app user (non-root user) will be able to write to the tmp folder. This is needed by rails and puma to
+# create pid session files, plus the cache and log files they generate
+# Change onwership of the folder from root to app, and the group to app's group (appgroup)
+RUN chown -R app: tmp
+
 # Specifiy listening port for the container
 EXPOSE 3000
 


### PR DESCRIPTION
We recently made the change [Fix issue with missing pids/ folder for puma](https://github.com/DEFRA/sroc-tcm-admin/pull/627) and thought all our issues with the `tmp/` folder and puma needing to create a pids folder were sorted. Well, that did nothing!

🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦

The change we made was to the source code. We ensured the folder got committed. Then, when running locally using docker-compose all was well. We'd obviously not had enough ☕️ that day because it wasn't solving the problem. When running locally our compose file was instructing Docker to mount the project folder into the container. So, hey-presto, we have a tmp folder. When we finally clocked that's what we were doing and removed the mount section, the error appeared again.

A _proper_ check of the solution has brought to light the problem.

- our .dockerignore was excluding `tmp/` from being added to the built image
- even if we did add it because we run everything using our **app** user, it wouldn't have permission to write to the folder anyway

So, this change

- tidies up our .gitignore entries around `tmp/` and `log/`
- adds `tmp/` into our .dockerignore as something to be retained
- adds `chown` to the Dockerfile to ensure the **app** user has full access to `tmp/`