### PR TITLE
Parameterise the AWS bucket region

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ FILE_UPLOAD_ACCESS_KEY=aws_access_key_here
 FILE_UPLOAD_SECRET_KEY=aws_secret_key_here/sAtb72OfEZw4MnsbP3uo
 FILE_UPLOAD_BUCKET=aws_s3_bucket_url_here
 ARCHIVE_BUCKET=aws_s3_bucket_url_here
+BUCKET_AWS_REGION=eu-west-1
 
 # Airbrake/Errbit settings
 AIRBRAKE_HOST=https://my-errbit-instance.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       FILE_UPLOAD_SECRET_KEY: iamanawss3secretkey
       FILE_UPLOAD_BUCKET: file-uploads-example-gov-uk
       ARCHIVE_BUCKET: file-archive-example-gov-uk
+      BUCKET_AWS_REGION: eu-west-1
 
     # Service containers to run with `runner-job`
     services:

--- a/app/lib/aws_file_store.rb
+++ b/app/lib/aws_file_store.rb
@@ -68,7 +68,7 @@ class AwsFileStore
   end
 
   def aws_region
-    "eu-west-1"
+    ENV["BUCKET_AWS_REGION"]
   end
 
   def aws_access_key

--- a/spec/support/helpers/s3_helpers.rb
+++ b/spec/support/helpers/s3_helpers.rb
@@ -3,23 +3,23 @@
 module Helpers
   module S3Helpers
     def self.any_request
-      %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/.*}
+      %r{https://.*\.s3\.#{ENV["BUCKET_AWS_REGION"]}\.amazonaws\.com/.*}
     end
 
     def self.any_bucket_regex(path = "", file_name = "")
-      %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/#{path}/#{file_name}}
+      %r{https://.*\.s3\.#{ENV["BUCKET_AWS_REGION"]}\.amazonaws\.com/#{path}/#{file_name}}
     end
 
     def self.list_uploads_regex(path = "")
-      %r{https://.*\.s3\.eu-west-1\.amazonaws\.com/\?list-type=2&prefix=#{path}}
+      %r{https://.*\.s3\.#{ENV["BUCKET_AWS_REGION"]}\.amazonaws\.com/\?list-type=2&prefix=#{path}}
     end
 
     def self.uploads_regex(path = "", file_name = "")
-      %r{https://#{ENV["FILE_UPLOAD_BUCKET"]}\.s3\.eu-west-1\.amazonaws\.com/#{path}/#{file_name}}
+      %r{https://#{ENV["FILE_UPLOAD_BUCKET"]}\.s3\.#{ENV["BUCKET_AWS_REGION"]}\.amazonaws\.com/#{path}/#{file_name}}
     end
 
     def self.archives_regex(path = "", file_name = "")
-      %r{https://#{ENV["ARCHIVE_BUCKET"]}\.s3\.eu-west-1\.amazonaws\.com/#{path}/#{file_name}}
+      %r{https://#{ENV["ARCHIVE_BUCKET"]}\.s3\.#{ENV["BUCKET_AWS_REGION"]}\.amazonaws\.com/#{path}/#{file_name}}
     end
 
     def self.list_response(path = "", file_name = "")


### PR DESCRIPTION
The current infrastructure runs in the `eu-west-1` region. The new ECS infrastructure is run in `eu-west-2` region. 

To enable concurrent functionality, the region parameter must be able to be changed as required. The proposed solution is via a new environment variable.