### PR TITLE
Fix github actions not triggering for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  push:
+on: [push, pull_request_target]
 
 jobs:
   build:


### PR DESCRIPTION
This came about when @sweavers-defra from our web-ops team attempted to [make a change](https://github.com/DEFRA/sroc-tcm-admin/pull/632) to support our work Dockerizing the TCM. They forked the repo, made the change and then submitted a PR which is what any external contributor would do.

But we found that our CI action would not trigger. Some Googling later and the possible cause was identified as not triggering the action when a [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event fires.

We want this to fire so both we and the contributor can see if the change has caused anything to break.

> Note - We base this on [How to Run GitHub Actions on Forks](https://dev.to/github/running-github-actions-on-forks-4e75). Other snippets we saw suggested it might be the more open [pull_request](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request). Do not be surprised if this change is followed by another!