### PR TITLE
Remove spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,10 +44,6 @@ group :development do
   # Manages our rubocop style rules for all defra ruby projects
   gem "defra_ruby_style"
   gem "listen", ">= 3.0.5", "< 3.2"
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem "spring"
-  gem "spring-watcher-listen", "~> 2.0.0"
-  # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,10 +330,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -408,8 +404,6 @@ DEPENDENCIES
   secure_headers
   selenium-webdriver
   simplecov (~> 0.17.1)
-  spring
-  spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-%w[
-  .ruby-version
-  .rbenv-vars
-  tmp/restart.txt
-  tmp/caching-dev.txt
-].each { |path| Spring.watch(path) }


### PR DESCRIPTION
We are getting this error when attempting to start the app in development mode or when trying to compile the assets.

```
/usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:120:in `start': undefined method `wait_for_state' for #<Listen::Listener:0x0000aaaaf4dc9368> (NoMethodError)
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:90:in `initialize'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `new'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `initialize'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:64:in `new'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:64:in `initialize_i18n'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:20:in `block in <class:Railtie>'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:85:in `with_execution_control'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:90:in `execute_hook'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:76:in `block in run_load_hooks'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `each'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `run_load_hooks'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application/finisher.rb:87:in `block in <module:Finisher>'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `instance_exec'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `run'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:61:in `block in run_initializers'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `call'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:60:in `run_initializers'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application.rb:372:in `initialize!'
        from /usr/src/app/config/environment.rb:7:in `<top (required)>'
        from config.ru:5:in `require_relative'
        from config.ru:5:in `block in <main>'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:116:in `eval'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:116:in `new_from_string'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:105:in `load_file'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:66:in `parse_file'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/server.rb:249:in `app'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/server.rb:422:in `wrapped_app'
        from /usr/src/gems/ruby/2.7.0/gems/rails_semantic_logger-4.12.0/lib/rails_semantic_logger/extensions/rails/server.rb:10:in `log_to_stdout'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:36:in `start'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:143:in `block in perform'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:134:in `tap'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:134:in `perform'
        from /usr/src/gems/ruby/2.7.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
        from /usr/src/gems/ruby/2.7.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/src/gems/ruby/2.7.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/command/base.rb:87:in `perform'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/command.rb:48:in `invoke'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```

We know it's to do with this statement in `config/environments/development.rb`

```ruby
config.file_watcher = ActiveSupport::EventedFileUpdateChecker
```

We'd seen mention it might be [spring](https://github.com/rails/spring) related, which we're not a fan of using anyway as things always seem to be 'flaky' when it is in the mix.

TBH, it didn't fix this issue but still pressing ahead with removing it just so it is one less complexity.