### PR TITLE
Fix asset compile and running app in Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request_target]
+on: push
 
 jobs:
   build:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,19 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  #
+  # NOTE: The default for this is ActiveSupport::EventedFileUpdateChecker and it worked fine when we first moved to
+  # Docker. But as of June 30 2023 it now causes an error when launching in development mode and during our Docker
+  # build when compiling the assets. The one clue we found was this
+  #
+  # https://dev.to/chrsgrrtt/rails-views-not-updating-locally-191o
+  #
+  # The writer identified the source as this line in the config being set to EventedFileUpdateChecker. They suggest
+  # it dislikes either Docker volumes or Windows. We already know FS events don't behave the same in Docker as when
+  # working locally so it's most likely true. But whilst they suggest commenting it out (also suggested in this
+  # issue https://github.com/rails/rails/issues/36158) a commenter to the post suggests switching it for
+  # FileUpdateChecker. Like others, this worked for us and means file watching is still enabled.
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # The rails web console allows you to execute arbitrary code on the server. By
   # default, only requests coming from IPv4 and IPv6 localhosts are allowed.


### PR DESCRIPTION
We spotted recently that the Docker build was failing to build with this error

```
[asset_builder 3/3] RUN bundle exec rake assets:precompile
2.986 rake aborted!
2.990 NoMethodError: undefined method `wait_for_state' for #<Listen::Listener:0x000055f35cfcda00>
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:120:in `start'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:90:in `initialize'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `new'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `initialize'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:64:in `new'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:64:in `initialize_i18n'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:20:in `block in <class:Railtie>'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:85:in `with_execution_control'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:90:in `execute_hook'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:76:in `block in run_load_hooks'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `each'
2.991 /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `run_load_hooks'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application/finisher.rb:87:in `block in <module:Finisher>'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `instance_exec'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `run'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:61:in `block in run_initializers'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:60:in `run_initializers'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application.rb:372:in `initialize!'
2.991 /usr/src/app/config/environment.rb:7:in `<top (required)>'
2.991 /usr/src/gems/ruby/2.7.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
2.991 /usr/src/gems/ruby/2.7.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application.rb:348:in `require_environment!'
2.991 /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application.rb:506:in `block in run_tasks_blocks'
2.991 /usr/src/gems/ruby/2.7.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/task.rb:61:in `block (2 levels) in define'
2.991 /usr/src/gems/ruby/2.7.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
2.991 /usr/local/bundle/bin/bundle:23:in `load'
2.991 /usr/local/bundle/bin/bundle:23:in `<main>'
2.991 Tasks: TOP => environment
2.991 (See full trace by running task with --trace)
ERROR: executor failed running [/bin/sh -c bundle exec rake assets:precompile]: exit code: 1
```

So, we pulled the repo down and attempted to run the app locally. But we got a similar error.

```
/usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:120:in `start': undefined method `wait_for_state' for #<Listen::Listener:0x0000aaaaf4dc9368> (NoMethodError)
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:90:in `initialize'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `new'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:42:in `initialize'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:64:in `new'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:64:in `initialize_i18n'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/i18n_railtie.rb:20:in `block in <class:Railtie>'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:85:in `with_execution_control'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:90:in `execute_hook'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:76:in `block in run_load_hooks'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `each'
        from /usr/src/gems/ruby/2.7.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `run_load_hooks'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application/finisher.rb:87:in `block in <module:Finisher>'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `instance_exec'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `run'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:61:in `block in run_initializers'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `call'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
        from /usr/local/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/initializable.rb:60:in `run_initializers'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/application.rb:372:in `initialize!'
        from /usr/src/app/config/environment.rb:7:in `<top (required)>'
        from config.ru:5:in `require_relative'
        from config.ru:5:in `block in <main>'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:116:in `eval'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:116:in `new_from_string'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:105:in `load_file'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/builder.rb:66:in `parse_file'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/server.rb:249:in `app'
        from /usr/src/gems/ruby/2.7.0/gems/rack-2.2.7/lib/rack/server.rb:422:in `wrapped_app'
        from /usr/src/gems/ruby/2.7.0/gems/rails_semantic_logger-4.12.0/lib/rails_semantic_logger/extensions/rails/server.rb:10:in `log_to_stdout'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:36:in `start'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:143:in `block in perform'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:134:in `tap'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands/server/server_command.rb:134:in `perform'
        from /usr/src/gems/ruby/2.7.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
        from /usr/src/gems/ruby/2.7.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/src/gems/ruby/2.7.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/command/base.rb:87:in `perform'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/command.rb:48:in `invoke'
        from /usr/src/gems/ruby/2.7.0/gems/railties-7.0.6/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```

The one clue we found was this [Rails views not updating locally? This might be why...](https://dev.to/chrsgrrtt/rails-views-not-updating-locally-191o). The writer identified the source as this line in the `config/environments/development.rb` being set to `EventedFileUpdateChecker`.

```ruby
config.file_watcher = ActiveSupport::FileUpdateChecker
```

They suggest `EventedFileUpdateChecker` dislikes either Docker volumes or Windows. We already know FS events don't behave the same in Docker as when working locally so it's most likely true. But whilst they say to comment it out (also suggested in this issue https://github.com/rails/rails/issues/36158) another commenter to the post suggests switching it for `FileUpdateChecker`. Like others, this worked for us and means file watching is still enabled.