### PR TITLE
Update Gemfile to match lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,10 @@
 source "https://rubygems.org"
 ruby "2.7.1"
 
-# Rails must be v6.1.3.1 or greater to avoid the issue around earlier versions of mimemagic and its use of GPL licensed
-# data. See https://github.com/rails/rails/issues/41750 and https://github.com/DEFRA/sroc-tcm-admin/pull/405 for more
-# details
-gem "rails", ">= 6.1.3.1"
+gem "rails", "~> 7.0"
 
 # Use postgresql as the database for Active Record
-gem "pg", "~> 1.2"
+gem "pg", "~> 1.5"
 
 gem "aws-sdk", "~> 2"
 # bootstrap 4
@@ -18,7 +15,7 @@ gem "bstard"
 gem "devise"
 gem "devise_invitable"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem "jbuilder", "~> 2.5"
+gem "jbuilder", "~> 2.11"
 # jquery needed by bootstrap for rails 5.1+
 gem "jquery-rails"
 gem "jquery-ui-rails"
@@ -31,14 +28,14 @@ gem "puma"
 gem "rails-i18n"
 gem "rails_semantic_logger"
 # Use SCSS for stylesheets
-gem "sass-rails", "~> 5.0"
+gem "sass-rails", "~> 5.1"
 gem "secure_headers"
 # Use Uglifier as compressor for JavaScript assets
-gem "uglifier", ">= 1.3.0"
+gem "uglifier", "~> 4.2"
 gem "whenever", require: false
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem "turbolinks", "~> 5"
+gem "turbolinks", "~> 5.2"
 
 group :development do
   # Manages our rubocop style rules for all defra ruby projects

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,26 +386,26 @@ DEPENDENCIES
   devise_invitable
   dotenv-rails
   factory_bot_rails
-  jbuilder (~> 2.5)
+  jbuilder (~> 2.11)
   jquery-rails
   jquery-ui-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
   mocha
   notifications-ruby-client
-  pg (~> 1.2)
+  pg (~> 1.5)
   puma
-  rails (>= 6.1.3.1)
+  rails (~> 7.0)
   rails-controller-testing
   rails-i18n
   rails_semantic_logger
   rspec-rails
-  sass-rails (~> 5.0)
+  sass-rails (~> 5.1)
   secure_headers
   selenium-webdriver
   simplecov (~> 0.17.1)
-  turbolinks (~> 5)
-  uglifier (>= 1.3.0)
+  turbolinks (~> 5.2)
+  uglifier (~> 4.2)
   web-console
   webmock
   whenever


### PR DESCRIPTION
We had spotted that we were running with versions of gems that were higher than specified in the Gemfile, for example, Rails was on v7 but the Gemfile makes it look like we are running v6.

So, as part of some housekeeping, we update the Gemfile to reflect what we are now locked to.