### PR TITLE
Fix asset pre-compile in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,9 +13,5 @@
 !Rakefile
 !tmp
 
-# re-ignore (!!) these files. Doing it this way means we avoid having to breakdown our entries above. For example, to
-# exclude app/assets the alternate would be to specify `!app/controllers, !app/helpers` etc above. This is less flexible
-# than using this method where we first include everything then add an exclusion for `app/assets`. We don't know how it
-# works but it does!
+# re-ignore (!!) these files. Doing it this way means we avoid having to breakdown our entries above.
 config/brakeman.ignore
-app/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ COPY . .
 # Copy the gems generated in the gem_builder stage from its image to this one
 COPY --from=gem_builder /usr/src/gems /usr/src/gems
 # Copy the assets in the asset_builder stage from its image to this one
-COPY --from=asset_builder /usr/src/app/public ./public
+COPY --from=asset_builder /usr/src/app/public /usr/src/app/public
 
 # This should be set in the project but just in case we ensure entrypoint.sh is executable
 RUN chmod +x entrypoint.sh


### PR DESCRIPTION
We now have an AWS environment we can deploy the production build of our Docker image. Only it immediately broke!

The error was related to a missing application.css asset which led us to look at what the `asset_builder` stage was doing in our Dockerfile.

We could see when we targeted `production` using `docker build` that the resulting image just had an empty sprockets manifest file generated in `/usr/src/app/public/assets`. But when we started our docker development environment and ran the same `bundle exec rake assets:precompile` everything worked perfectly.

We finally tracked it down and it was a proper 🤦🤦🤦🤦🤦 moment. For some reason that we can't fathom now, we'd told docker to ignore `app/assets` when copying the source code into the image! 😱

This meant `bundle exec rake assets:precompile` was running fine, only there were no assets to compile. The reason it worked when running the docker development environment is because our `docker-compose.yml` mounts the repo into the container i.e. `app/assets` exists when the command is run.

Whilst debugging we also tweaked the `COPY` command. It wasn't needed but it keeps things consistent with how we do the gems so we left the change in.