### PR TITLE
Update Dependabot config to check GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
+- package-ecosystem: "github-actions"
+  # Workflow files stored in the default location of `.github/workflows`
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
When looking to clean up the warning messages we are getting when our GitHub actions run we spotted some were to do with the version of actions being used.

That's when we realised the TCM unlike our other repos does not have Dependabot configured to check the GitHub actions we are using.

This change fixes that.