### PR TITLE
Push built images to AWS ECR instead of GCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,14 +22,19 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones block `git describe --always --tags` from working later in 'Set all tags'
 
-      # Login against a GitHub Container registry
-      # https://github.com/docker/login-action
-      - name: Log into GH Container Registry
-        uses: docker/login-action@v2
+      # Configure our AWS credentials and region environment variables for use in other GitHub Actions
+      # https://github.com/aws-actions/configure-aws-credentials
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          registry: ${{ env.GHC_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          aws-region: ${{ secrets.AWS_ENV_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ENV_ACCOUNT }}:role/${{ secrets.AWS_ENV_ROLE }}
+
+      # Login to AWS ECR private. It will use the credentials we configured in the previous step
+      # https://github.com/aws-actions/amazon-ecr-login
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action


### PR DESCRIPTION
The new environments we're building for the SROC TCM which will be Docker based will pull their images from AWS ECR. We have just been storing the images in GitHub Container Registry (GCR) whilst we have been waiting for it to be built.

We now have an ECR repo and login credentials. This is our first attempt to build and push our images to it.

Though the [Docker login-action](https://github.com/docker/login-action#aws-elastic-container-registry-ecr) supports AWS ECR, it only does so using a Key and a Secret Access Key. Our web-ops team and AWS prefer it if we instead assume a role using IAM which is why we are now using the [configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) and [amazon-ecr-login](https://github.com/aws-actions/amazon-ecr-login) actions.

Thanks to this post; [Build And Push Docker Image to AWS ECR using GitHub Actions](https://medium.com/@anshita.bhasin/build-and-push-docker-image-to-aws-ecr-using-github-actions-506e9f77f7f8) we believe it should work!