### PR TITLE
Update docker workflow to include OIDC permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We're going to be honest, we're not really sure what we are doing here!

But our [first attempt to switch to AWS ECR](https://github.com/DEFRA/sroc-tcm-admin/pull/683) resulted in this error when `.github/workflows/docker.yml` first ran.

```
Run aws-actions/configure-aws-credentials@v2
  with:
    aws-region: ***
    role-to-assume: arn:aws:iam::***:role/***
    audience: sts.amazonaws.com
  env:
    GHC_REGISTRY: ghcr.io
    IMAGE_NAME: DEFRA/sroc-tcm-admin
(node:1782) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

Doing a Google just came up with lots of posts from various sources all seeming to say the credentials are wrong. We've assumed that is not the cause in this case so we looked for other reasons. There is a CCOE template we've been using for reference that we saw had this section in its workflow.

```yaml
jobs:
  provision-runner:
    name: Provision AWS Runner
    runs-on: ubuntu-latest
    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
    permissions:
      id-token: write
      contents: read
```

We'd seen mention of the GitHub OIDC endpoint in the [configure-aws-credentials docs](https://github.com/aws-actions/configure-aws-credentials#recent-updates). When we double-checked an [expanded example](https://github.com/aws-actions/configure-aws-credentials#recent-updates) we also saw the same section.

So, before we go asking web-ops to check the credentials they provided we're adding this section in to see if it helps.