### PR TITLE
Fix repo details in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,10 +8,7 @@ on:
     tags: [ 'v*.*.*' ]
 
 env:
-  # Our main, default container registry
-  GHC_REGISTRY: ghcr.io
-  # github.repository will be <account>/<repo>, for example, DEFRA/sroc-tcm-admin
-  IMAGE_NAME: ${{ github.repository }}
+  REPOSITORY: tactical_charging_module/sroc-tcm-admin
 
 jobs:
   build:
@@ -46,7 +43,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.GHC_REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
 
       # The combination of the original tags plus the sed calculated ones are combined and stored as a multiline string
       # in a new env var.


### PR DESCRIPTION
When we updated `.github/workflows/docker.yml` to switch from pushing to GitHub Container Registry (GCR) to AWS ECR we overlooked the need to update other details (hey, we don't touch this that often!)

We were still creating an image that was based on the GCR registry and the repo name `DEFRA/sroc-tcm-admin`. We need to build our image using the correct registry and repo details else the docker push will be trying the wrong registry!