### PR TITLE
Fix missed outdated docker workflow reference

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "ghcr.io/defra/sroc-tcm-admin:$(git describe --always --tags)"; fi >> $GITHUB_ENV
+          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}:$(git describe --always --tags)"; fi >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       # Build and push Docker image with Buildx


### PR DESCRIPTION
In [Push built images to AWS ECR instead of GCR](https://github.com/DEFRA/sroc-tcm-admin/pull/683) we updated our Docker workflow to push our images to AWS ECR instead of GitHub Container Registry (GCR).

We then spotted we'd forgotten to update some references and fixed those in [Fix repo details in Docker workflow](https://github.com/DEFRA/sroc-tcm-admin/pull/685).

Clearly, we're not paying attention because we have spotted another reference we have forgotten to update.

Doh!