### PR TITLE
Set licence label in Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
+          labels: |
+            org.opencontainers.image.licenses=OGL-UK-3.0
 
       # The combination of the original tags plus the sed calculated ones are combined and stored as a multiline string
       # in a new env var.


### PR DESCRIPTION
Because we have been digging into the GitHub action logs in recent changes we spotted that the licence label was being left blank.

```
Run docker/metadata-action@v4
Context info
Processing images input
Processing tags input
Processing flavor input
Docker image version
Docker tags
Docker labels
  org.opencontainers.image.created=2023-08-06T10:30:10.284Z
  org.opencontainers.image.description=Administration application for the tactical charging module
  org.opencontainers.image.licenses=
  org.opencontainers.image.revision=733ce43f365961c0621d709dd03df6b6448b61ea
  org.opencontainers.image.source=https://github.com/DEFRA/sroc-tcm-admin
  org.opencontainers.image.title=sroc-tcm-admin
  org.opencontainers.image.url=https://github.com/DEFRA/sroc-tcm-admin
  org.opencontainers.image.version=main
```

Probably because we're not using a typical licence like MIT. Anyway, according to the [metadata-action docs](https://github.com/docker/metadata-action#overwrite-labels) we can overwrite any labels generated. We do so in this change to plug that gap.