### PR TITLE
Amend docker tagging for AWS ECR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
       - name: Generate raw tag
         id: raw-tag
         run: |
-          echo "{NVMRC}={cat .ruby-version}" >> $GITHUB_OUTPUT
-          echo "raw_tag={git describe --always --tags}" >> $GITHUB_OUTPUT
+          RAW_TAG=$(git describe --always --tags)
+          echo "NVMRC=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
+          echo "raw_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Check raw tag
         id: check-raw-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,17 @@ jobs:
           {
             echo "### :label: Docker Image details"
             echo "- **${{ steps.raw-tag.outputs.raw_tag }}**"
+            echo "\n"
             echo "|Label | Value |"
             echo "|------|-------|"
-            echo "|created| - |"
-            echo "|description| - |"
-            echo "|licenses| - |"
-            echo "|revision| - |"
-            echo "|source| - |"
-            echo "|title| - |"
-            echo "|url| - |"
-            echo "|version| - |"
+            echo "|created| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }} |"
+            echo "|description| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }} |"
+            echo "|licenses| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.licenses'] }} |"
+            echo "|revision| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }} |"
+            echo "|source| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.source'] }} |"
+            echo "|title| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.title'] }} |"
+            echo "|url| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.url'] }} |"
+            echo "|version| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} |"
           } >> $GITHUB_STEP_SUMMARY
 
       # # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,52 +45,54 @@ jobs:
 
       - name: Generate raw tag
         id: raw-tag
-        run:
+        run: |
+          echo "{NVMRC}={cat .ruby-version}" >> $GITHUB_OUTPUT
           echo "raw_tag={git describe --always --tags}" >> $GITHUB_OUTPUT
 
       - name: Check raw tag
         id: check-raw-tag
-        run:
+        run: |
+          echo "The NVMRC is ${{ steps.raw-tag.outputs.NVMRC }}"
           echo "The raw tag is ${{ steps.raw-tag.outputs.raw_tag }}"
 
-      # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the
-      # tests
-      #
-      # Reworking of https://stackoverflow.com/a/21788642/6117745
-      - name: Temporary tag check
-        run: |
-          ! grep --exclude=spec_helper.rb -R ':focus\|focus:' spec
+      # # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the
+      # # tests
+      # #
+      # # Reworking of https://stackoverflow.com/a/21788642/6117745
+      # - name: Temporary tag check
+      #   run: |
+      #     ! grep --exclude=spec_helper.rb -R ':focus\|focus:' spec
 
-      # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
-      # version from .ruby-verion itself
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      # # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
+      # # version from .ruby-verion itself
+      # - name: Install Ruby
+      #   uses: ruby/setup-ruby@v1
+      #   with:
+      #     bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - name: Database migrations
-        run: |
-          RAILS_ENV=test bundle exec rake db:migrate
+      # - name: Database migrations
+      #   run: |
+      #     RAILS_ENV=test bundle exec rake db:migrate
 
-      # Run linting first. No point running the tests if there is a linting issue
-      - name: Run lint check
-        run: |
-          bundle exec rubocop --format progress --format json --out rubocop-result.json
+      # # Run linting first. No point running the tests if there is a linting issue
+      # - name: Run lint check
+      #   run: |
+      #     bundle exec rubocop --format progress --format json --out rubocop-result.json
 
-      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
-      # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
-      # sed to update the references in .resultset.json
-      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
-      - name: Run unit tests
-        run: |
-          bundle exec rails test
-          bundle exec rspec
-          sed -i 's/\/home\/runner\/work\/sroc-tcm-admin\/sroc-tcm-admin\//\/github\/workspace\//g' coverage/.resultset.json
+      # # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
+      # # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
+      # # sed to update the references in .resultset.json
+      # # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      # - name: Run unit tests
+      #   run: |
+      #     bundle exec rails test
+      #     bundle exec rspec
+      #     sed -i 's/\/home\/runner\/work\/sroc-tcm-admin\/sroc-tcm-admin\//\/github\/workspace\//g' coverage/.resultset.json
 
-      - name: Analyze with SonarCloud
-        if: github.actor != 'dependabot[bot]'
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+      # - name: Analyze with SonarCloud
+      #   if: github.actor != 'dependabot[bot]'
+      #   uses: sonarsource/sonarcloud-github-action@master
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,36 @@ jobs:
         run:
           echo "raw_tag=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
 
-      - name: Check raw tag
-        id: check-raw-tag
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
+          tags: |
+            type=semver,priority=900,pattern={{raw}}
+            type=raw,priority=800,value=${{ steps.raw-tag.outputs.raw_tag }}
+          labels: |
+            org.opencontainers.image.licenses=OGL-UK-3.0
+
+      - name: Job summary
+        id: summary
         run: |
-          echo "The raw tag is ${{ steps.raw-tag.outputs.raw_tag }}"
+          {
+            echo "### :label: Docker Image details"
+            echo "- **${{ steps.raw-tag.outputs.raw_tag }}**"
+            echo "|Label | Value |"
+            echo "|------|-------|"
+            echo "|created| - |"
+            echo "|description| - |"
+            echo "|licenses| - |"
+            echo "|revision| - |"
+            echo "|source| - |"
+            echo "|title| - |"
+            echo "|url| - |"
+            echo "|version| - |"
+          } >> $GITHUB_STEP_SUMMARY
 
       # # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the
       # # tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,23 @@ jobs:
       ARCHIVE_BUCKET: file-archive-example-gov-uk
       BUCKET_AWS_REGION: eu-west-1
 
-    # Service containers to run with `runner-job`
-    services:
-      # Label used to access the service container
-      postgres:
-        # Docker Hub image
-        image: postgres:12.5-alpine
-        # Provide the password for postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pinafore
-          POSTGRES_DB: sroc_tcm_test
-        # Maps tcp port 5432 on service container to the host
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started. You must have this so the runner knows to wait till
-        # postgres is up and running before proceeding
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    # # Service containers to run with `runner-job`
+    # services:
+    #   # Label used to access the service container
+    #   postgres:
+    #     # Docker Hub image
+    #     image: postgres:12.5-alpine
+    #     # Provide the password for postgres
+    #     env:
+    #       POSTGRES_USER: postgres
+    #       POSTGRES_PASSWORD: pinafore
+    #       POSTGRES_DB: sroc_tcm_test
+    #     # Maps tcp port 5432 on service container to the host
+    #     ports:
+    #       - 5432:5432
+    #     # Set health checks to wait until postgres has started. You must have this so the runner knows to wait till
+    #     # postgres is up and running before proceeding
+    #     options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
@@ -45,9 +45,8 @@ jobs:
 
       - name: Generate raw tag
         id: raw-tag
-        run: |
-          RAW_TAG=$(git describe --always --tags)
-          echo "raw_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
+        run:
+          echo "raw_tag=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Check raw tag
         id: check-raw-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,23 @@ jobs:
       ARCHIVE_BUCKET: file-archive-example-gov-uk
       BUCKET_AWS_REGION: eu-west-1
 
-    # # Service containers to run with `runner-job`
-    # services:
-    #   # Label used to access the service container
-    #   postgres:
-    #     # Docker Hub image
-    #     image: postgres:12.5-alpine
-    #     # Provide the password for postgres
-    #     env:
-    #       POSTGRES_USER: postgres
-    #       POSTGRES_PASSWORD: pinafore
-    #       POSTGRES_DB: sroc_tcm_test
-    #     # Maps tcp port 5432 on service container to the host
-    #     ports:
-    #       - 5432:5432
-    #     # Set health checks to wait until postgres has started. You must have this so the runner knows to wait till
-    #     # postgres is up and running before proceeding
-    #     options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    # Service containers to run with `runner-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres:12.5-alpine
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: pinafore
+          POSTGRES_DB: sroc_tcm_test
+        # Maps tcp port 5432 on service container to the host
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started. You must have this so the runner knows to wait till
+        # postgres is up and running before proceeding
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
@@ -43,80 +43,44 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
-      - name: Generate raw tag
-        id: raw-tag
-        run:
-          echo "raw_tag=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
-          tags: |
-            type=semver,priority=900,pattern={{raw}}
-            type=raw,priority=800,value=${{ steps.raw-tag.outputs.raw_tag }}
-          labels: |
-            org.opencontainers.image.licenses=OGL-UK-3.0
-
-      - name: Job summary
-        id: summary
+      # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the
+      # tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
         run: |
-          {
-            echo "### Docker Image details"
-            echo "The tag is **${{ steps.raw-tag.outputs.raw_tag }}**."
-            echo "| Label      | Value |"
-            echo "| ---------- | ----- |"
-            echo "| created    | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }} |"
-            echo "| description| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }} |"
-            echo "| licenses   | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.licenses'] }} |"
-            echo "| revision   | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }} |"
-            echo "| source     | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.source'] }} |"
-            echo "| title      | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.title'] }} |"
-            echo "| url        | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.url'] }} |"
-            echo "| version    | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} |"
-          } >> $GITHUB_STEP_SUMMARY
+          ! grep --exclude=spec_helper.rb -R ':focus\|focus:' spec
 
-      # # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the
-      # # tests
-      # #
-      # # Reworking of https://stackoverflow.com/a/21788642/6117745
-      # - name: Temporary tag check
-      #   run: |
-      #     ! grep --exclude=spec_helper.rb -R ':focus\|focus:' spec
+      # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
+      # version from .ruby-verion itself
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      # # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
-      # # version from .ruby-verion itself
-      # - name: Install Ruby
-      #   uses: ruby/setup-ruby@v1
-      #   with:
-      #     bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Database migrations
+        run: |
+          RAILS_ENV=test bundle exec rake db:migrate
 
-      # - name: Database migrations
-      #   run: |
-      #     RAILS_ENV=test bundle exec rake db:migrate
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          bundle exec rubocop --format progress --format json --out rubocop-result.json
 
-      # # Run linting first. No point running the tests if there is a linting issue
-      # - name: Run lint check
-      #   run: |
-      #     bundle exec rubocop --format progress --format json --out rubocop-result.json
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
+      # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
+      # sed to update the references in .resultset.json
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          bundle exec rails test
+          bundle exec rspec
+          sed -i 's/\/home\/runner\/work\/sroc-tcm-admin\/sroc-tcm-admin\//\/github\/workspace\//g' coverage/.resultset.json
 
-      # # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
-      # # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
-      # # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
-      # # sed to update the references in .resultset.json
-      # # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
-      # - name: Run unit tests
-      #   run: |
-      #     bundle exec rails test
-      #     bundle exec rspec
-      #     sed -i 's/\/home\/runner\/work\/sroc-tcm-admin\/sroc-tcm-admin\//\/github\/workspace\//g' coverage/.resultset.json
-
-      # - name: Analyze with SonarCloud
-      #   if: github.actor != 'dependabot[bot]'
-      #   uses: sonarsource/sonarcloud-github-action@master
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+      - name: Analyze with SonarCloud
+        if: github.actor != 'dependabot[bot]'
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           RAW_TAG=$(git describe --always --tags)
           echo "raw_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
-          echo "Raw tag generated: $RAW_TAG" >> $GITHUB_STEP_SUMMARY
 
       - name: Check raw tag
         id: check-raw-tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
 
+      - name: Generate raw tag
+        id: raw-tag
+        run:
+          echo "raw_tag={git describe --always --tags}" >> $GITHUB_OUTPUT
+
+      - name: Check raw tag
+        id: check-raw-tag
+        run:
+          echo "The raw tag is ${{ steps.raw-tag.outputs.raw_tag }}"
+
       # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the
       # tests
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,19 +65,18 @@ jobs:
         id: summary
         run: |
           {
-            echo "### :label: Docker Image details"
-            echo "- **${{ steps.raw-tag.outputs.raw_tag }}**"
-            echo "\n"
-            echo "|Label | Value |"
-            echo "|------|-------|"
-            echo "|created| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }} |"
-            echo "|description| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }} |"
-            echo "|licenses| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.licenses'] }} |"
-            echo "|revision| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }} |"
-            echo "|source| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.source'] }} |"
-            echo "|title| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.title'] }} |"
-            echo "|url| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.url'] }} |"
-            echo "|version| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} |"
+            echo "### Docker Image details"
+            echo "The tag is **${{ steps.raw-tag.outputs.raw_tag }}**."
+            echo "| Label      | Value |"
+            echo "| ---------- | ----- |"
+            echo "| created    | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }} |"
+            echo "| description| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }} |"
+            echo "| licenses   | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.licenses'] }} |"
+            echo "| revision   | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }} |"
+            echo "| source     | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.source'] }} |"
+            echo "| title      | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.title'] }} |"
+            echo "| url        | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.url'] }} |"
+            echo "| version    | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} |"
           } >> $GITHUB_STEP_SUMMARY
 
       # # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,12 @@ jobs:
         id: raw-tag
         run: |
           RAW_TAG=$(git describe --always --tags)
-          echo "NVMRC=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
           echo "raw_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
+          echo "Raw tag generated: $RAW_TAG" >> $GITHUB_STEP_SUMMARY
 
       - name: Check raw tag
         id: check-raw-tag
         run: |
-          echo "The NVMRC is ${{ steps.raw-tag.outputs.NVMRC }}"
           echo "The raw tag is ${{ steps.raw-tag.outputs.raw_tag }}"
 
       # # Before we do anything, check we haven't accidentally left any `:focus` or `focus: :true` statements in the

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,27 +55,6 @@ jobs:
           labels: |
             org.opencontainers.image.licenses=OGL-UK-3.0
 
-      # The combination of the original tags plus the sed calculated ones are combined and stored as a multiline string
-      # in a new env var.
-      #
-      # Some things to note
-      #  - each line of the HEREDOC must output something. That is why we call 'echo' in each one
-      #  - steps.meta.outputs.tags is itself a multiline string so we must wrap the call in quotes else the second line
-      #    of the string is interpreted as a command
-      #  - GitHub action's `set-output` truncates multiline strings which is why we have resorted to what you see below
-      #    to get a value which contains all the possible tags as a multiline string
-      #  - the 'if' determines if this is a push to `main` or a new tag. If a push to `main` we add a unique tag, for
-      #    example `v0.13.2-2-g9ce6d11`. This is to support testing
-      #
-      # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#multiline-strings
-      # https://github.community/t/set-output-truncates-multiline-strings/16852/8
-      # - name: Set all tags
-      #   run: |
-      #     echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
-      #     echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-      #     if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}:$(git describe --always --tags)"; fi >> $GITHUB_ENV
-      #     echo 'EOF' >> $GITHUB_ENV
-
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,11 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Generate raw tag
+        id: raw-tag
+        run:
+          echo "raw_tag={git describe --always --tags}" >> $GITHUB_OUTPUT
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -44,6 +49,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
+          tags: |
+            type=semver,priority=900,pattern={{raw}}
+            type=raw,priority=800,value=${{ steps.raw-tag.outputs.raw_tag }}
           labels: |
             org.opencontainers.image.licenses=OGL-UK-3.0
 
@@ -61,12 +69,12 @@ jobs:
       #
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#multiline-strings
       # https://github.community/t/set-output-truncates-multiline-strings/16852/8
-      - name: Set all tags
-        run: |
-          echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
-          if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}:$(git describe --always --tags)"; fi >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+      # - name: Set all tags
+      #   run: |
+      #     echo 'ALL_TAGS<<EOF' >> $GITHUB_ENV
+      #     echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_ENV
+      #     if [ ${{ startsWith(github.ref, 'refs/tags/v') }} = false ]; then echo "${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}:$(git describe --always --tags)"; fi >> $GITHUB_ENV
+      #     echo 'EOF' >> $GITHUB_ENV
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
In [Push built images to AWS ECR instead of GCR](https://github.com/DEFRA/sroc-tcm-admin/pull/683) we started the changes to switch to AWS ECR.

We'd forgotten that the AWS ECR registry that has been set up enforces tag immutability. This means we can't rely on a tagging strategy that uses `:main`, `:production` or `:latest`. There must be a unique 1-to-1 reference between images and tags.

Our tagging strategy before was

- let [metadata-action](https://github.com/docker/metadata-action) generate tags using it's default settings
- test if the action was because a new tag was pushed `startsWith(github.ref, 'refs/tags/v')`
- if it wasn't then add our own custom tag to what **metadata-action** generated
- push the image with those tags

The result was

- when a tag is pushed the only tag generated is `:v1.2.3` (for example)
- when it is just a push then 2 tags are generated; `:main` and `:v3.2.1-158-g733ce43` (for example)

Now we couldn't have **metadata-action** generating `:main`. So, we returned to the docs, this time a little more informed. What we found was

- we don't need to roll our own step checking what the ref starts with and making decisions based on it
- we can get **metadata-action** to do everything we need

Using its config we tell it the types of tags we want created and their priority. So, now we use a simple step to generate the tag for normal pushes to `main`. Then we tell **metadata-action**

- if the workflow was triggered because of a new tag, only create a [semver](https://semver.org/) based tag using whatever tag was pushed
- for everything else only create a tag using the tag we generated

No more scary bash code in the workflow, we're using the action as intended, and we can run the workflow without AWS ECR telling us off!