### PR TITLE
Fix tags used in build-push-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,4 +66,4 @@ jobs:
             GIT_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           push: true
           labels: ${{ steps.meta_github.outputs.labels }}
-          tags: ${{ env.ALL_TAGS }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
In [Amend docker tagging for AWS ECR](https://github.com/DEFRA/sroc-tcm-admin/pull/688) we amended our Docker workflow to just use what [metadata-action](https://github.com/docker/metadata-action) generates.

We removed our custom step that was taking that output and creating our own env var called `ALL_TAGS`. The only problem is we didn't update the [build-push-action](https://github.com/docker/build-push-action) accordingly.

Doh!