### PR TITLE
Add job summary and comments to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,12 +37,41 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      # Generate a unique tag
+      # Most tutorials will suggest you just use the commit sha as a way of creating a unique tag for your image.
+      # In our experience though this tells us nothing about the image we are working with. You have to search
+      # GitHub or the commit history to figure out what you have in the image. Instead, we use
+      # `git describe --always --tags` to generate a more meaningful tag, for example, `v3.2.1-162-g8ff3690`.
+      # This tag broken down means
+      #
+      # - the last tag created for my main branch was v3.2.1
+      # - there have been 162 commits to that branch since that tag was created
+      # - the `g` just denotes that the source control system is git
+      # - the abbreviated commit reference for the lastest commit is 8ff3690
+      #
+      # From this we get a better sense of just what version of the code the image was built on. For reference the
+      # `git describe --always --tags` command broken down means
+      #
+      # - `--always` If no tags existed nothing would be shown. As a fallback we include this argument to tell it to
+      #   always return the abbreviated commit reference for the last commit.
+      # - `--tags` By default the command only works with annotated tags which is fine for us as that's all we use. But
+      #   just in case we tell it to reference all tags created, both annotated and lightweight
+      # https://git-scm.com/docs/git-describe
       - name: Generate raw tag
         id: raw-tag
         run:
           echo "raw_tag=$(git describe --always --tags)" >> $GITHUB_OUTPUT
 
-      # Extract metadata (tags, labels) for Docker
+      # Extract metadata from Git reference and GitHub events
+      # We use it to generate the tags and labels for our Docker image. For reference;
+      #
+      # - images: the base name to use for the full tag. The build-push-action will also use this to determine where
+      #   to push the image to
+      # - tags: tell the action to generate certain tags dependent on the event. Our config says when a tag is pushed
+      #   use the pushed git tag as the image tag. Else use the custom raw_tag we generated in the previous step
+      # - labels: because we don't use a common licence like MIT, the licences label doesn't get populated. We can
+      #   overwrite any of the labels but in our case you just ensure this one gets set
+      #
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
@@ -67,3 +96,24 @@ jobs:
           push: true
           labels: ${{ steps.meta_github.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+
+      # Generate a summary that will be displayed against the Job when selected in the Actions tab.
+      # We this to quickly see details for the image generated instead of digging into the build output.
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+      - name: Generate job summary
+        id: summary
+        run: |
+          {
+            echo "### Docker Image details"
+            echo "The tag is **${{ steps.raw-tag.outputs.raw_tag }}**"
+            echo "| Label      | Value |"
+            echo "| ---------- | ----- |"
+            echo "| created    | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }} |"
+            echo "| description| ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }} |"
+            echo "| licenses   | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.licenses'] }} |"
+            echo "| revision   | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }} |"
+            echo "| source     | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.source'] }} |"
+            echo "| title      | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.title'] }} |"
+            echo "| url        | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.url'] }} |"
+            echo "| version    | ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} |"
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
We started the journey to [Push built images to AWS ECR instead of GCR](https://github.com/DEFRA/sroc-tcm-admin/pull/683) a few PR's ago. We faced a few bumps, some of our own making. But now everything appears to be working as expected.

To finish things off we add detailed comments to our workflow so others can follow what we are doing. We also (because we can 😎) generate a Job Summary in the workflow. In future, we should then be able to see at a glance all the details for the image we've pushed.