### PR TITLE
Fix docker.yml build labels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
           push: true
-          labels: ${{ steps.meta_github.outputs.labels }}
+          labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
 
       # Generate a summary that will be displayed against the Job when selected in the Actions tab.


### PR DESCRIPTION
We spotted an intellisense warning for our Docker workflow in the "Build and push Docker image" step.

It's not caused a problem, but we're not 100% certain labels were ever correctly being assigned to the image because of this.

We know we have the syntax right for the tags, and making this change removes the intellisense warning.