### PR TITLE
Disable latest tag handling in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,6 +65,8 @@ jobs:
       # Extract metadata from Git reference and GitHub events
       # We use it to generate the tags and labels for our Docker image. For reference;
       #
+      # - flavor: defines global behaviour for tags. By default a GitHub tag event would cause metadata-action to
+      #   apply the `latest` tag. But as our AWS ECR has immutable tags we can't use `latest`
       # - images: the base name to use for the full tag. The build-push-action will also use this to determine where
       #   to push the image to
       # - tags: tell the action to generate certain tags dependent on the event. Our config says when a tag is pushed
@@ -77,6 +79,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
+          flavor: |
+            latest=false
           images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
           tags: |
             type=semver,priority=900,pattern={{raw}}


### PR DESCRIPTION
As part of switching to AWS ECR we realised we needed to [Amend docker tagging for AWS ECR](https://github.com/DEFRA/sroc-tcm-admin/pull/688). This is because the ECR registry we are pushing to has been configured to use immutable tags.

We are ensuring we generate only a unique tag for pushes to `main` and no longer use a `:main` tag. But when we tested pushing a new git tag we saw that [metadata-action](https://github.com/docker/metadata-action/tree/master#latest-tag) was generating a `:latest` tag as well.

By default, a GitHub tag event causes **metadata-action** to apply the `:latest` tag. You can disable this by configuring `flavor:` which defines global behaviour for tags in the action. This change does that.