### PR TITLE
Fix local setup of docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN addgroup -S appgroup && adduser -S app -G appgroup
 
 # force_ruby_platform:- Ignore the current machine's platform and install only ruby platform gems. As a result, gems
 # with native extensions will be compiled from source. This helps ensure the gems are built for this image
-RUN gem install bundler \
+RUN gem install bundler -v 2.4.22 \
   && bundle config force_ruby_platform true
 
 ################################################################################


### PR DESCRIPTION
When trying to build the image from scratch locally recently we were getting an error with `bundler`. This was because we were not specifying a version for bundler, and its latest version is now incompatible with Ruby 2.7.1 which we are running.

Amending the Dockerfile to specify the version to install resolved the problem.