### PR TITLE
Add back in Annual billing upload functionality

### DIFF
--- a/app/controllers/annual_billing_data_files_controller.rb
+++ b/app/controllers/annual_billing_data_files_controller.rb
@@ -47,9 +47,8 @@ class AnnualBillingDataFilesController < ApplicationController
     @upload = data_service.upload(file_params)
 
     if @upload.errors.empty? && @upload.save
-      # start background job
-      AnnualBillingDataImportJob.perform_later(current_user.id, @upload.id)
-      # the show page will display progress while importing
+      # start import
+      AnnualBillingDataImportService.call(user: current_user, upload: @upload)
       redirect_to regime_annual_billing_data_file_path(@regime, @upload)
     else
       render "new"

--- a/app/controllers/annual_billing_data_files_controller.rb
+++ b/app/controllers/annual_billing_data_files_controller.rb
@@ -4,9 +4,10 @@ class AnnualBillingDataFilesController < ApplicationController
   include ViewModelBuilder
   include RegimeScope
 
-  before_action :set_regime, only: %i[index show]
+  before_action :set_regime, only: %i[index new create]
+  before_action :set_upload, only: %i[show edit update]
 
-  # GET /regimes/:regime_id/annual_billing_data_files
+  # GET /regimes/:regime_id/transactions
   def index
     # list of uploads
     @uploads = @regime.annual_billing_data_files.order(created_at: :desc)
@@ -14,7 +15,7 @@ class AnnualBillingDataFilesController < ApplicationController
 
   # GET /regimes/:regime_id/annual_billing_data_files/1
   def show
-    @upload = @regime.annual_billing_data_files.find(params[:id])
+    # @upload = @regime.annual_billing_data_files.find(params[:id])
     @view_model = build_annual_billing_view_model
 
     respond_to do |format|
@@ -26,5 +27,79 @@ class AnnualBillingDataFilesController < ApplicationController
         end
       end
     end
+  end
+
+  # GET /regimes/:regimes_id/transactions/1/edit
+  def edit
+    # possible re-run matching and merging process?
+  end
+
+  # PATCH/PUT /regimes/:regimes_id/transactions/1
+  def update
+    # possible re-run matching and merging process?
+  end
+
+  def new
+    @upload = data_service.new_upload
+  end
+
+  def create
+    @upload = data_service.upload(file_params)
+
+    if @upload.errors.empty? && @upload.save
+      # start background job
+      AnnualBillingDataImportJob.perform_later(current_user.id, @upload.id)
+      # the show page will display progress while importing
+      redirect_to regime_annual_billing_data_file_path(@regime, @upload)
+    else
+      render "new"
+    end
+  end
+
+  private
+
+  def set_upload
+    set_regime
+    @upload = data_service.find(params[:id])
+  end
+
+  def file_params
+    params.require(:annual_billing_data_file).permit(:data_file)
+  end
+
+  def present_errors(errors)
+    error_data = errors.map do |e|
+      {
+        id: e.id,
+        line_number: e.line_number,
+        message: e.message
+      }
+    end
+    {
+      errors: error_data,
+      pagination: {
+        current_page: errors.current_page,
+        prev_page: errors.prev_page,
+        next_page: errors.next_page,
+        per_page: errors.limit_value,
+        total_pages: errors.total_pages,
+        total_count: errors.total_count
+      }
+    }
+  end
+
+  def present_file(upload, errors)
+    {
+      filename: File.basename(upload.filename),
+      upload_date: helpers.formatted_date(upload.created_at, include_time: true),
+      status: upload.status.humanize,
+      success_count: upload.success_count,
+      failed_count: upload.failed_count,
+      error_list: present_errors(errors)
+    }
+  end
+
+  def data_service
+    @data_service ||= AnnualBillingDataFileService.new(@regime, current_user)
   end
 end

--- a/app/services/annual_billing_data_file_service.rb
+++ b/app/services/annual_billing_data_file_service.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class AnnualBillingDataFileService
+  include RegimeScope
+  include AnnualBillingDataFileFormat
+
+  attr_reader :regime, :user
+
+  def initialize(regime, user)
+    @regime = regime
+    @user = user
+  end
+
+  def new_upload(params = {})
+    regime.annual_billing_data_files.build(params)
+  end
+
+  def find(id)
+    regime.annual_billing_data_files.find(id)
+  end
+
+  def upload(params = {})
+    record = regime.annual_billing_data_files.build(number_of_records: 0,
+                                                    status: "new")
+    data_file = params.fetch(:data_file, nil)
+    if data_file
+      if valid_file? data_file.tempfile
+        begin
+          # upload to S3
+          filename = File.basename(data_file.original_filename)
+          dest_file = File.join(storage_path, filename)
+          PutAnnualBillingDataFile.call(local_path: data_file.tempfile.path,
+                                        remote_path: dest_file)
+
+          record.filename = dest_file
+          record.state.upload!
+        rescue StandardError => e
+          record.errors.add(:base, e.message)
+        end
+      else
+        record.errors.add(:base, "This file type is not supported.  " \
+                          "Please upload a correctly formatted CSV " \
+                          "file (.csv)")
+      end
+    else
+      record.errors.add(:base, "Select a annual billing data file (.csv) " \
+                        "to import")
+    end
+    record
+  end
+
+  def valid_file?(file)
+    # check file looks reasonable
+    csv = CSV.new(file,
+                  headers: true,
+                  return_headers: true,
+                  header_converters: lambda { |h|
+                                       TcmUtils.strip_bom(h).parameterize.underscore.to_sym
+                                     },
+                  field_size_limit: 32)
+    csv.shift
+    headers = csv.headers
+    valid = true
+    mandatory_headers.each { |h| valid = false unless headers.include? h }
+    valid
+  rescue CSV::MalformedCSVError => e
+    Rails.logger.warn(e.message)
+    false
+  rescue StandardError => e
+    Rails.logger.error(e.message)
+    false
+  end
+
+  def mandatory_headers
+    send("#{regime.to_param}_mandatory_column_names")
+  end
+
+  def regime_headers
+    send("#{regime.to_param}_columns")
+  end
+
+  def storage_path
+    File.join(regime.to_param, Time.zone.now.strftime("%Y%m%d%H%M%S"))
+  end
+
+  def import(upload, path)
+    set_current_user
+    headers = regime_headers
+    key_header = headers.select { |h| h.fetch(:unique_reference, false) }.first
+    key_column = key_header[:header]
+    ref_column = key_header[:column]
+    update_columns = headers.reject { |h| h[:header] == key_column }
+
+    counter = 1
+    CSV.foreach(path, headers: true,
+                      header_converters: lambda { |h|
+                                           TcmUtils.strip_bom(h).parameterize.underscore.to_sym
+                                         },
+                      field_size_limit: 32) do |row|
+      counter += 1
+      failed = false
+      ref_value = row.fetch(key_column)
+
+      transaction = find_matching_transaction(upload, counter, key_column,
+                                              ref_column, ref_value)
+
+      if transaction.nil?
+        # errors logged in #find_matching_transaction
+        failed = true
+      else
+        # we have a transaction
+        update_columns.each do |col|
+          next if failed
+
+          val = row.fetch(col[:header], nil)
+
+          if val.blank? && col[:mandatory]
+            upload.log_error(counter, "No value for mandatory field #{present_column(col[:header])}")
+            failed = true
+          elsif val.present?
+            case col[:header]
+            when :permit_category
+              # validate against categories first
+              # this needs to be against the new way of working now
+              # if !regime.permit_categories.where(code: val).exists
+              failed = !Query::PermitCategoryExists.call(regime: @regime,
+                                                         category: val,
+                                                         financial_year: transaction.tcm_financial_year)
+            when :variation
+              # check it's a positive number between 0 - 100
+              # will always be an integer as they round down any fractional values
+              begin
+                i = Integer(val.to_s, 10)
+                raise ArgumentError if i.negative? || i > 100
+
+                val += "%" unless val.include?("%")
+              rescue ArgumentError
+                failed = true
+              end
+            when :temporary_cessation
+              # check for Y or N
+              v = val.downcase
+              if v != "y" && v != "n"
+                failed = true
+              else
+                val = (v == "y")
+              end
+            end
+
+            if failed
+              upload.log_error(counter, "Invalid #{present_column(col[:header])} value: '#{val}'")
+            else
+              transaction.send("#{col[:column]}=", val)
+            end
+          end
+        end
+
+        unless failed
+          if transaction.changed?
+            # (re)calculate the charge if the transaction has changed
+            transaction.charge_calculation = CalculateCharge.call(transaction: transaction).charge_calculation
+            if transaction.charge_calculation_error?
+              # what should we do here? revoke the changes and mark as an error?
+              upload.log_error(counter,
+                               "Calculation error: #{TransactionCharge.extract_calculation_error(transaction)}")
+              failed = true
+            else
+              transaction.tcm_charge = TransactionCharge.extract_correct_charge(transaction)
+              if transaction.save
+                upload.success_count += 1
+              else
+                upload.log_error(counter, upload.errors.full_messages.join(", "))
+                failed = true
+              end
+            end
+          else
+            # changes didn't affect the transaction values already set
+            upload.success_count += 1
+          end
+        end
+      end
+      upload.failed_count += 1 if failed
+      upload.save
+    end
+  end
+
+  def find_matching_transaction(upload, line_no, key_column, ref_column, ref_value)
+    transactions = regime.transaction_details.unbilled.where(ref_column => ref_value).order(:updated_at)
+
+    if transactions.count.zero?
+      upload.log_error(line_no, "Could not find #{present_column(key_column)} matching '#{ref_value}'")
+      nil
+    elsif regime.water_quality? && transactions.count > 1
+      # cannot have duplicates for WQ - apparently consent references are
+      # only unique within a region not the regime - so possible duplicates could
+      # be found although this would be an error and shouldn't happen we need
+      # to cater for the possiblity...
+      regions = regions_for_transactions(transactions)
+
+      column_name = present_column(key_column)
+      region_count = "region".pluralize(regions.count)
+
+      upload.log_error(
+        line_no,
+        "Multiple transactions found for #{column_name}: '#{ref_value}' in #{region_count} #{regions.join(', ')}"
+      )
+      nil
+    else
+      # if multiple matches, it apparently doesn't matter which one we select,
+      # but to ensure the all get updated if there are multiple in the import
+      # file, always select the oldest modified one to update
+      transactions.first
+    end
+  end
+
+  def regions_for_transactions(list)
+    TransactionHeader.where(id: list.pluck(:transaction_header_id).uniq).pluck(:region).uniq.sort
+  end
+
+  def set_current_user
+    # so we can pick up the user for auditing changes
+    Thread.current[:current_user] = user
+  end
+end

--- a/app/services/annual_billing_data_import_service.rb
+++ b/app/services/annual_billing_data_import_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AnnualBillingDataImportService < ServiceObject
+  def initialize(params = {})
+    super()
+
+    @upload = params.fetch(:upload)
+    @user = params.fetch(:user)
+  end
+
+  def call
+    @result = false
+    file = Tempfile.new
+
+    begin
+      # update upload record status
+      @upload.state.process!
+
+      regime = @upload.regime
+      GetAnnualBillingDataFile.call(remote_path: @upload.filename,
+                                    local_path: file.path)
+
+      file.rewind
+
+      data_service = AnnualBillingDataFileService.new(regime, @user)
+
+      data_service.import(@upload, file.path)
+
+      # update upload record status
+      @upload.state.complete!
+
+      @result = true
+    rescue StandardError => e
+      # update upload record status
+      upload.state.error!
+
+      TcmLogger.notify(e)
+    ensure
+      file.close
+      file.unlink
+
+      puts("Finished annual billing data import")
+    end
+
+    self
+  end
+end

--- a/app/views/annual_billing_data_files/_csv_help.html.erb
+++ b/app/views/annual_billing_data_files/_csv_help.html.erb
@@ -1,0 +1,13 @@
+<details>
+  <summary role="button" aria-controls="csv-file-help">
+    <span class="summary">Help with the <strong><%= regime.title %></strong> CSV file format</span>
+  </summary>
+  <div class="panel" id="csv-file-help">
+    <p class="col-lg-8"><em>CSV</em> stands for <em>'Comma Separated Values'</em>.
+    A CSV formatted file contains one record per-row with
+    each field in the record delimited by a comma (',').
+    Each row in the file should contain the following fields:</p>
+
+    <%= annual_billing_csv_column_descriptions_for(regime) %>
+  </div>
+</details>

--- a/app/views/annual_billing_data_files/_form.html.erb
+++ b/app/views/annual_billing_data_files/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with(model: [@regime, upload], local: true, html: { multipart: true } ) do |form| %>
+  <%= error_header(upload) %>
+
+  <div class="col-lg-6">
+    <div class="form-group">
+      <%= form.file_field :data_file,
+          accept: upload.file_types,
+          aria: { labelledby: 'annual-billing-data-upload' } %>
+      <%= form.hidden_field :id %>
+    </div>
+
+    <div class="actions">
+      <%= form.submit class: "btn btn-primary" %>
+      <%= link_to 'Back', regime_permit_categories_path(@regime),
+        class: "btn btn-secondary", role: "button" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/annual_billing_data_files/_upload_details.html.erb
+++ b/app/views/annual_billing_data_files/_upload_details.html.erb
@@ -1,0 +1,12 @@
+<dl class="row" id="upload-details">
+  <dt class="col-sm-4 col-md-3">Filename</dt>
+  <dd class="col-sm-7 col-md-8"><%= File.basename @upload.filename %></dd>
+  <dt class="col-sm-4 col-md-3">Date uploaded</dt>
+  <dd class="col-sm-7 col-md-8"><%= formatted_date(@upload.created_at, include_time: true) %></dd>
+  <dt class="col-sm-4 col-md-3">Status</dt>
+  <dd class="col-sm-7 col-md-8" id="upload-status"><%= @upload.status.humanize %></dd>
+  <dt class="col-sm-4 col-md-3">Records updated</dt>
+  <dd class="col-sm-7 col-md-8"><%= @upload.success_count %></dd>
+  <dt class="col-sm-4 col-md-3">Errors detected</dt>
+  <dd class="col-sm-7 col-md-8"><%= @upload.failed_count %></dd>
+</dl>

--- a/app/views/annual_billing_data_files/index.html.erb
+++ b/app/views/annual_billing_data_files/index.html.erb
@@ -3,6 +3,13 @@
     <h1 id="annual-billing-data-heading">Annual Billing Data Files</h1>
   </div>
 </div>
+<div class="row mb-4">
+  <div class="col">
+    <%= link_to 'Upload Annual Billing Data',
+      new_regime_annual_billing_data_file_path(@regime),
+      class: 'btn btn-primary', role: 'button' %>
+  </div>
+</div>
 <div class="row">
   <div class="col">
     <table class="table table-responsive">

--- a/app/views/annual_billing_data_files/new.html.erb
+++ b/app/views/annual_billing_data_files/new.html.erb
@@ -1,0 +1,34 @@
+<div class="row mb-4">
+  <div class="col">
+    <h1 id="annual-billing-data-heading">Upload Annual Billing Data</h1>
+  </div>
+</div>
+
+<%= form_with(model: [@regime, @upload], local: true,
+              class: "annual-billing-upload",
+              html: { multipart: true } ) do |form| %>
+  <%= error_header(@upload, title: "Unable to proceed") %>
+  <div class="row">
+    <div class="col">
+      <p>Select the annual billing data file to upload (<strong>CSV</strong> format).</p>
+      <%= render partial: 'csv_help', locals: { regime: @regime } %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-6">
+      <div class="form-group">
+        <%= form.file_field :data_file,
+          accept: @upload.file_types,
+          aria: { labelledby: 'annual-billing-data-heading' } %>
+        <%= form.hidden_field :id %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg-6 actions">
+      <%= form.submit 'Upload and Import Data',  class: "btn btn-primary" %>
+      <%= link_to 'Cancel', regime_annual_billing_data_files_path(@regime),
+        class: "btn btn-secondary", role: "button" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/menu/_annual_billing.html.erb
+++ b/app/views/shared/menu/_annual_billing.html.erb
@@ -3,6 +3,10 @@
     Annual Billing
   </a>
   <div class="dropdown-menu" aria-labelledby="navbarAnnualBillingSelectorLink">
+    <%= link_to "Upload Annual Billing Data",
+                new_regime_annual_billing_data_file_path(@regime),
+                class: "dropdown-item",
+                role: "menuitem" %>
     <%= link_to "Review Annual Billing Data",
                 regime_annual_billing_data_files_path(@regime),
                 class: "dropdown-item",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     resources :transaction_summary, only: %i[index show]
     resources :retrospective_files, only: [:create]
     resources :retrospective_summary, only: [:index]
-    resources :annual_billing_data_files, only: %i[index show]
+    resources :annual_billing_data_files, except: [:destroy]
     resources :exclusion_reasons, except: [:show]
     resources :data_export, only: [:index] do
       get "download", on: :collection

--- a/test/services/annual_billing_data_file_service_test.rb
+++ b/test/services/annual_billing_data_file_service_test.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AnnualBillingDataFileServiceTest < ActiveSupport::TestCase
+  include ChargeCalculation
+
+  def setup
+    @regime = regimes(:cfd)
+    @user = users(:billing_admin)
+    @service = AnnualBillingDataFileService.new(@regime, @user)
+
+    build_mock_calculator
+    # @calculator = build_mock_calculator
+    # @service.stubs(:calculator).returns(@calculator)
+  end
+
+  def test_new_upload_returns_instance_of_annual_billing_data_file
+    upload = @service.new_upload
+    assert_instance_of AnnualBillingDataFile, upload
+  end
+
+  def test_new_upload_returns_initialised_model
+    upload = @service.new_upload
+    assert_equal @regime, upload.regime
+  end
+
+  def test_find_locates_annual_billing_files_by_id
+    data_file = annual_billing_data_files(:cfd)
+    assert_equal data_file, @service.find(data_file.id)
+  end
+
+  def test_find_raises_not_found_error_when_unmatched
+    bad_id = AnnualBillingDataFile.maximum(:id) + 10
+    assert_raises(ActiveRecord::RecordNotFound) { @service.find(bad_id) }
+  end
+
+  def test_valid_file_returns_true_when_valid
+    File.open(file_fixture("cfd_abd.csv"), "r") do |f|
+      assert @service.valid_file?(f)
+    end
+  end
+
+  def test_valid_file_returns_false_when_invalid
+    File.open(file_fixture("invalid.csv"), "r") do |f|
+      refute @service.valid_file?(f)
+    end
+  end
+
+  def test_import_updates_matching_transactions_in_regime
+    file = file_fixture("cfd_abd.csv")
+    transaction = sroc_transaction
+    assert_nil transaction.category
+    refute transaction.temporary_cessation
+
+    upload = prepare_upload(file)
+    @service.import(upload, file)
+
+    transaction.reload
+    assert_equal "2.3.4", transaction.category
+    assert transaction.temporary_cessation
+  end
+
+  def test_import_calculates_charge_for_updated_transactions
+    file = file_fixture("cfd_abd.csv")
+    transaction = sroc_transaction
+    assert_nil transaction.charge_calculation
+
+    upload = prepare_upload(file)
+    @service.import(upload, file)
+
+    transaction.reload
+    assert_not_nil transaction.charge_calculation
+  end
+
+  def test_import_extracts_and_converts_calculated_charge_amount
+    file = file_fixture("cfd_abd.csv")
+    transaction = sroc_transaction
+    assert_nil transaction.charge_calculation
+
+    upload = prepare_upload(file)
+    @service.import(upload, file)
+
+    transaction.reload
+    amt = (transaction.charge_calculation["calculation"]["chargeValue"] * 100).round
+    amt = -amt if transaction.line_amount.negative?
+    assert_equal amt, transaction.tcm_charge
+  end
+
+  def test_import_does_not_update_transactions_outside_regime
+    file = file_fixture("cfd_abd.csv")
+
+    transaction = transaction_details(:pas)
+    assert_nil transaction.category
+    refute transaction.temporary_cessation
+
+    upload = prepare_upload(file)
+    @service.import(upload, file)
+
+    transaction.reload
+    assert_nil transaction.category
+    refute transaction.temporary_cessation
+  end
+
+  def test_import_correctly_set_temporary_cessation
+    file = file_fixture("cfd_abd.csv")
+    upload = prepare_upload(file)
+
+    transaction = sroc_transaction
+    transaction2 = transaction.dup
+    transaction2.reference_1 = "ANNF/1754/1/1"
+    transaction2.save
+
+    @service.import(upload, file)
+    assert_equal(true, transaction.reload.temporary_cessation)
+    assert_equal(false, transaction2.reload.temporary_cessation)
+  end
+
+  def test_import_handles_zero_variation
+    file = file_fixture("cfd_abd_zero_variation.csv")
+    upload = prepare_upload(file)
+
+    transaction = sroc_transaction
+    transaction2 = transaction.dup
+    transaction2.reference_1 = "ANNF/1754/1/1"
+    transaction2.save
+    transaction3 = transaction.dup
+    transaction3.reference_1 = "ZNNNF/1754/1/1"
+    transaction3.save
+
+    @service.import(upload, file)
+    assert_equal("22%", transaction.reload.variation)
+    assert_equal("0%", transaction2.reload.variation)
+    assert_equal("84%", transaction3.reload.variation)
+  end
+
+  def test_import_stores_variation_with_an_percent_suffix
+    file = file_fixture("cfd_abd.csv")
+    upload = prepare_upload(file)
+
+    transaction = sroc_transaction
+    transaction2 = transaction.dup
+    transaction2.reference_1 = "ANNF/1754/1/1"
+    transaction2.save
+
+    @service.import(upload, file)
+    assert transaction.reload.variation.end_with?("%")
+    assert transaction2.reload.variation.end_with?("%")
+  end
+
+  def test_import_records_total_and_errors
+    file = file_fixture("cfd_abd.csv")
+    upload = prepare_upload(file)
+    transaction = sroc_transaction
+    transaction2 = transaction.dup
+    transaction2.reference_1 = "ANNF/1754/1/1"
+    transaction2.save
+
+    @service.import(upload, file)
+    assert_equal 2, upload.success_count
+    assert_equal 2, upload.failed_count
+    assert_equal 2, upload.data_upload_errors.count
+  end
+
+  def test_import_creates_audit_records
+    file = file_fixture("cfd_abd.csv")
+    upload = prepare_upload(file)
+    transaction = sroc_transaction
+    transaction2 = transaction.dup
+    transaction2.reference_1 = "ANNF/1754/1/1"
+    transaction2.save!
+
+    assert_difference("AuditLog.count", 2) do
+      @service.import(upload, file)
+    end
+    assert_equal(@user, AuditLog.last.user)
+  end
+
+  def test_import_creates_audit_log_of_changes
+    file = file_fixture("cfd_abd.csv")
+    upload = prepare_upload(file)
+
+    transaction = sroc_transaction
+
+    @service.import(upload, file)
+
+    log = transaction.reload.audit_logs.last
+    changes = log.payload["modifications"]
+
+    assert_equal([nil, "2.3.4"], changes["category"])
+    assert_equal([false, true], changes["temporary_cessation"])
+    assert_equal([nil, "88%"], changes["variation"])
+    assert_not_nil(changes["charge_calculation"])
+    assert_not_nil(changes["tcm_charge"])
+  end
+
+  def prepare_upload(file)
+    upload = @service.new_upload(filename: File.basename(file))
+    upload.state.upload!
+    upload
+  end
+
+  def sroc_transaction
+    transaction = transaction_details(:cfd)
+    transaction.tcm_financial_year = "1819"
+    transaction.period_start = "1-APR-2018"
+    transaction.period_end = "31-MAR-2019"
+    transaction.save!
+    transaction
+  end
+end


### PR DESCRIPTION
When last working on the project as part of work to remove redis and [resque](https://github.com/resque/resque) dependencies we [removed Annual billing upload functionality](https://github.com/DEFRA/sroc-tcm-admin/pull/416).

We were told this was a defunct feature and only needed when the service went live. Removing it saved us from updating the code to no longer use Resque.

The problem is, we need it back!

As part of getting ready for EPR in 2024, the TCM regimes need to load 20,000 new activities and their charge categories. This was what the 'Annual billing upload' was built for so they'd like it back.

This change adds it back into the UI and the service. We can't just copy the code we deleted though as we now need to do the work to strip the dependence on resque. Fortunately, other jobs like the file import and export processes have already gone through this.